### PR TITLE
Cozy 158 회원가입api

### DIFF
--- a/app/src/main/java/umc/cozymate/data/model/entity/TokenInfo.kt
+++ b/app/src/main/java/umc/cozymate/data/model/entity/TokenInfo.kt
@@ -6,9 +6,9 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class TokenInfo(
     @SerialName("accessToken")
-    val accessToken: String,
+    var accessToken: String,
     @SerialName("message")
-    val message: String,
+    var message: String,
     @SerialName("refreshToken")
-    val refreshToken: String?
+    var refreshToken: String?
 )

--- a/app/src/main/java/umc/cozymate/data/repository/repository/RoomRepository.kt
+++ b/app/src/main/java/umc/cozymate/data/repository/repository/RoomRepository.kt
@@ -3,8 +3,14 @@ package umc.cozymate.data.repository.repository
 import retrofit2.Response
 import umc.cozymate.data.model.request.CreateRoomRequest
 import umc.cozymate.data.model.response.room.CreateRoomResponse
+import umc.cozymate.data.model.response.room.GetRoomInfoByInviteCodeResponse
 
 interface RoomRepository {
+
+    suspend fun getRoomInfoByInviteCode(accessToken: String, inviteCode: String): Response<GetRoomInfoByInviteCodeResponse>
+
+    suspend fun joinRoom(accessToken: String, roomId: Int, memberId: Int)
+
     suspend fun createRoom(accessToken: String, roomInfo: CreateRoomRequest): Response<CreateRoomResponse<CreateRoomResponse.SuccessResult>>
 }
 

--- a/app/src/main/java/umc/cozymate/data/repository/repositoryImpl/RoomRepositoryImpl.kt
+++ b/app/src/main/java/umc/cozymate/data/repository/repositoryImpl/RoomRepositoryImpl.kt
@@ -4,12 +4,24 @@ import retrofit2.Response
 import umc.cozymate.data.api.RoomService
 import umc.cozymate.data.model.request.CreateRoomRequest
 import umc.cozymate.data.model.response.room.CreateRoomResponse
+import umc.cozymate.data.model.response.room.GetRoomInfoByInviteCodeResponse
 import umc.cozymate.data.repository.repository.RoomRepository
 import javax.inject.Inject
 
 class RoomRepositoryImpl @Inject constructor(
     private val api: RoomService
 ) : RoomRepository {
+
+    override suspend fun getRoomInfoByInviteCode(
+        accessToken: String,
+        inviteCode: String
+    ): Response<GetRoomInfoByInviteCodeResponse> {
+        return api.getRoomInfoByInviteCode(accessToken, inviteCode)
+    }
+
+    override suspend fun joinRoom(accessToken: String, roomId: Int, memberId: Int) {
+        return api.joinRoom(accessToken, roomId, memberId)
+    }
 
 
     override suspend fun createRoom(accessToken: String, roomInfo: CreateRoomRequest): Response<CreateRoomResponse<CreateRoomResponse.SuccessResult>> {

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/entering_room/CozyHomeEnteringViewModel.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/entering_room/CozyHomeEnteringViewModel.kt
@@ -1,0 +1,6 @@
+package umc.cozymate.ui.cozy_home.entering_room
+
+class CozyHomeEnteringViewModel {
+
+
+}

--- a/app/src/main/java/umc/cozymate/ui/onboarding/DatePickerBottomSheetFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/onboarding/DatePickerBottomSheetFragment.kt
@@ -1,29 +1,15 @@
 package umc.cozymate.ui.onboarding
 
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.NumberPicker
-import androidx.annotation.RequiresApi
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import umc.cozymate.databinding.CustomDatepickerBinding
 import java.time.LocalDate
 
-// 프래그먼트에 생년월일 값 전달하기 위한 인터페이스
-/*interface AlertPickerDialogInterface {
-    fun onClickDoneButton(date:String, )
-}*/
-
-@RequiresApi(Build.VERSION_CODES.O)
-class DatePickerBottomSheetFragment(
-    //pickerDialogInterface: AlertPickerDialogInterface,
-    //id: Int,
-    //year: Int = LocalDate.now().year,
-    //month: Int = LocalDate.now().monthValue,
-    //day: Int = LocalDate.now().dayOfMonth
-)
+class DatePickerBottomSheetFragment
     : BottomSheetDialogFragment() {
 
     interface AlertPickerDialogInterface {
@@ -38,9 +24,6 @@ class DatePickerBottomSheetFragment(
     private val monthsArr = (1..12).toList().map { it.toString() }.toTypedArray()
     private val daysArr = (1..31).toList().map { it.toString() }.toTypedArray()
 
-    private var pickerDialogInterface: AlertPickerDialogInterface? = null
-    private var id: Int? = null
-
     private var listener: AlertPickerDialogInterface? = null
 
     // 선택된 값
@@ -52,8 +35,6 @@ class DatePickerBottomSheetFragment(
         this.year = LocalDate.now().year
         this.month = LocalDate.now().month.value
         this.day = LocalDate.now().dayOfMonth
-        // this.id = id
-        //this.pickerDialogInterface = pickerDialogInterface
     }
 
     override fun onCreateView(
@@ -71,9 +52,9 @@ class DatePickerBottomSheetFragment(
             // 값 가져오기
             var year = binding.npYear.value.toString()
             year = when {
-                year.startsWith("1") -> "19" + year[1].toString()+ year[2].toString()
-                year.startsWith("2") -> "20" + year[1].toString()+ year[2].toString()
-                else -> "19" + year[1].toString()+ year[2].toString()
+                year.length == 2 -> "19" + year[0].toString()+ year[1].toString()
+                year.length == 3 -> "20" + year[1].toString()+ year[2].toString()
+                else -> "19" + year[0].toString()+ year[1].toString()
             }
 
             var month = (binding.npMonth.value + 1).toString()
@@ -90,7 +71,7 @@ class DatePickerBottomSheetFragment(
             }
 
             var selectedDate = "2024-08-04" // Replace this with actual date selection logic
-            selectedDate = year + "년 " + month + "월 " + day + "일"
+            selectedDate = year + "-" + month + "-" + day
 
             listener?.onClickDoneButton(selectedDate)
             dismiss()

--- a/app/src/main/java/umc/cozymate/ui/onboarding/DatePickerBottomSheetFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/onboarding/DatePickerBottomSheetFragment.kt
@@ -10,7 +10,6 @@ import androidx.annotation.RequiresApi
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import umc.cozymate.databinding.CustomDatepickerBinding
 import java.time.LocalDate
-import java.util.Calendar
 
 // 프래그먼트에 생년월일 값 전달하기 위한 인터페이스
 /*interface AlertPickerDialogInterface {
@@ -71,7 +70,11 @@ class DatePickerBottomSheetFragment(
         binding.btnSave.setOnClickListener {
             // 값 가져오기
             var year = binding.npYear.value.toString()
-            if (binding.npYear.value.toString().length == 3) year = "20" + year[1].toString()+ year[2].toString()
+            year = when {
+                year.startsWith("1") -> "19" + year[1].toString()+ year[2].toString()
+                year.startsWith("2") -> "20" + year[1].toString()+ year[2].toString()
+                else -> "19" + year[1].toString()+ year[2].toString()
+            }
 
             var month = (binding.npMonth.value + 1).toString()
             if (month.length == 1) month = "0" + month
@@ -87,19 +90,17 @@ class DatePickerBottomSheetFragment(
             }
 
             var selectedDate = "2024-08-04" // Replace this with actual date selection logic
-            selectedDate = year + "-" + month + "-" + day
+            selectedDate = year + "년 " + month + "월 " + day + "일"
 
             listener?.onClickDoneButton(selectedDate)
             dismiss()
 
-            //this.pickerDialogInterface?.onClickDoneButton(id!!, year!!, month!!, day!!)
 
             // 프래그먼트 매니저를 사용하여 뒤로가기 처리 및 데이터 전달
             parentFragmentManager.setFragmentResult("requestKey", bundle)
             parentFragmentManager.popBackStack()
         }
 
-        //initDatePicker()
         initDatepicker()
     }
 
@@ -136,22 +137,6 @@ class DatePickerBottomSheetFragment(
             npMonth.value = month-1//currentDate.monthValue
             npDay.value = day-1//currentDate.dayOfMonth
         }
-    }
-
-    private fun getDaysInMonth(year: Int, month: Int): Int {
-        val calendar = Calendar.getInstance()
-        calendar.set(Calendar.YEAR, year)
-        calendar.set(Calendar.MONTH, month - 1)
-        return calendar.getActualMaximum(Calendar.DAY_OF_MONTH)
-    }
-
-    private fun getDisplayValues(start: Int, end: Int, suffix: String): Array<String> {
-        val displayValues = mutableListOf<String>()
-
-        for (value in start..end) {
-            displayValues.add("${value}${suffix}")
-        }
-        return displayValues.toTypedArray()
     }
 
     fun setOnDateSelectedListener(listener: AlertPickerDialogInterface ) {

--- a/app/src/main/java/umc/cozymate/ui/onboarding/OnboardingUserInfoFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/onboarding/OnboardingUserInfoFragment.kt
@@ -74,9 +74,9 @@ class OnboardingUserInfoFragment : Fragment() {
     // 성별 선택 시 이미지 변경
     private fun toggleImage(isSelected: Boolean, iv: ImageView) {
         if (isSelected) {
-            iv.setImageResource(R.drawable.iv_radio_unselected)
-        } else {
             iv.setImageResource(R.drawable.iv_radio_selected)
+        } else {
+            iv.setImageResource(R.drawable.iv_radio_unselected)
         }
     }
 
@@ -238,6 +238,11 @@ class OnboardingUserInfoFragment : Fragment() {
             }
 
             radioMale.setOnClickListener {
+                // 성별 선택 상태를 초기화
+                isSelectedMale = true
+                isSelectedFemale = false
+
+                // ui 업데이트
                 etOnboardingName.clearFocus()
                 etOnboardingNickname.clearFocus()
                 mcvBirth.isSelected = false
@@ -245,13 +250,17 @@ class OnboardingUserInfoFragment : Fragment() {
                 updateColors()
                 viewModel.setGender("MALE")
 
-                isSelectedMale = !isSelectedMale
+                // 이미지 업데이트
                 toggleImage(isSelectedMale, ivMale)
-                isSelectedFemale = !isSelectedMale
                 toggleImage(isSelectedFemale, ivFemale)
             }
 
             radioFemale.setOnClickListener {
+                // 성별 선택 상태를 초기화
+                isSelectedMale = false
+                isSelectedFemale = true
+
+                // ui 업데이트
                 etOnboardingName.clearFocus()
                 etOnboardingNickname.clearFocus()
                 mcvBirth.isSelected = false
@@ -259,9 +268,8 @@ class OnboardingUserInfoFragment : Fragment() {
                 updateColors()
                 viewModel.setGender("FEMALE")
 
-                isSelectedFemale = !isSelectedFemale
+                // 이미지 업데이트
                 toggleImage(isSelectedFemale, ivFemale)
-                isSelectedMale = !isSelectedFemale
                 toggleImage(isSelectedMale, ivMale)
             }
         }

--- a/app/src/main/java/umc/cozymate/ui/onboarding/OnboardingUserInfoFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/onboarding/OnboardingUserInfoFragment.kt
@@ -32,6 +32,7 @@ class OnboardingUserInfoFragment : Fragment() {
     private var isSelectedMale = true
     private var isSelectedFemale = false
 
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -75,7 +76,54 @@ class OnboardingUserInfoFragment : Fragment() {
     }
 
     private fun setupTextWatchers() {
-        val textWatcher = object : TextWatcher {
+        val namePattern = "^[ㄱ-ㅎㅏ-ㅣ가-힣]+$".toRegex() // 한글
+        val nicknamePattern = "^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]{2,8}$".toRegex() // 2-8자의 한글,영어,숫자
+
+        binding.etOnboardingName.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                val input = s.toString()
+                if (!namePattern.matches(input)) {
+                    binding.tvLabelName.setTextColor(resources.getColor(R.color.red))
+                    binding.tvAlertName.visibility = View.VISIBLE
+                    binding.tilOnboardingName.isErrorEnabled = true
+                    binding.tilOnboardingName.boxStrokeColor = resources.getColor(R.color.red)
+                } else {
+                    binding.tvLabelName.setTextColor(resources.getColor(R.color.main_blue))
+                    binding.tvAlertName.visibility = View.GONE
+                    binding.tilOnboardingName.isErrorEnabled = false
+                    binding.tilOnboardingName.boxStrokeColor = resources.getColor(R.color.sub_skyblue)
+                }
+                updateNextBtnState()
+            }
+
+            override fun afterTextChanged(s: Editable?) {}
+        })
+        binding.etOnboardingNickname.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                val input = s.toString()
+                if (!nicknamePattern.matches(input)) {
+                    binding.tvLabelNickname.setTextColor(resources.getColor(R.color.red))
+                    binding.tvAlertNickname.visibility = View.VISIBLE
+                    binding.tilOnboardingNickname.isErrorEnabled = true
+                    binding.tilOnboardingNickname.boxStrokeColor = resources.getColor(R.color.red)
+                } else {
+                    binding.tvLabelNickname.setTextColor(resources.getColor(R.color.main_blue))
+                    binding.tvAlertNickname.visibility = View.GONE
+                    binding.tilOnboardingNickname.isErrorEnabled = false
+                    binding.tilOnboardingNickname.boxStrokeColor = resources.getColor(R.color.sub_color1)
+
+                    viewModel.nicknameCheck()
+                }
+                updateNextBtnState()
+            }
+
+            override fun afterTextChanged(s: Editable?) {}
+        })
+        binding.tvBirth.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
@@ -83,10 +131,7 @@ class OnboardingUserInfoFragment : Fragment() {
             }
 
             override fun afterTextChanged(s: Editable?) {}
-        }
-        binding.etOnboardingName.addTextChangedListener(textWatcher)
-        binding.etOnboardingNickname.addTextChangedListener(textWatcher)
-        binding.tvBirth.addTextChangedListener(textWatcher)
+        })
     }
 
     fun updateNextBtnState() {
@@ -107,7 +152,7 @@ class OnboardingUserInfoFragment : Fragment() {
             viewModel.setName(name)
             viewModel.setNickname(nickname)
             viewModel.setBirthday(birth)
-            viewModel.setGender(gender)
+            // viewModel.setGender(gender)
 
             parentFragmentManager.beginTransaction()
                 .replace(R.id.fragment_onboarding, OnboardingSelectingCharacterFragment())
@@ -132,7 +177,7 @@ class OnboardingUserInfoFragment : Fragment() {
             intArrayOf() // 포커스되지 않은 상태
         )
         val colors = intArrayOf(
-            ContextCompat.getColor(requireContext(), R.color.main_blue), // 포커스된 상태의 색상
+            ContextCompat.getColor(requireContext(), R.color.sub_color1), // 포커스된 상태의 색상
             ContextCompat.getColor(requireContext(), R.color.unuse)
         )
         val colorStateList = ColorStateList(states, colors)
@@ -186,6 +231,7 @@ class OnboardingUserInfoFragment : Fragment() {
                 mcvBirth.isSelected = false
                 mcvGender.isSelected = true
                 updateColors()
+                viewModel.setGender("MALE")
 
                 isSelectedMale = !isSelectedMale
                 toggleImage(isSelectedMale, ivMale)
@@ -199,6 +245,7 @@ class OnboardingUserInfoFragment : Fragment() {
                 mcvBirth.isSelected = false
                 mcvGender.isSelected = true
                 updateColors()
+                viewModel.setGender("FEMALE")
 
                 isSelectedFemale = !isSelectedFemale
                 toggleImage(isSelectedFemale, ivFemale)
@@ -211,7 +258,7 @@ class OnboardingUserInfoFragment : Fragment() {
     private fun updateColors() {
         with(binding) {
             if (mcvBirth.isSelected) {
-                setStrokeColor(mcvBirth, R.color.main_blue)
+                setStrokeColor(mcvBirth, R.color.sub_color1)
                 setTextColor(tvLabelBirth, R.color.main_blue)
             } else {
                 setStrokeColor(mcvBirth, R.color.unuse)
@@ -219,7 +266,7 @@ class OnboardingUserInfoFragment : Fragment() {
             }
 
             if (mcvGender.isSelected) {
-                setStrokeColor(mcvGender, R.color.main_blue)
+                setStrokeColor(mcvGender, R.color.sub_color1)
                 setTextColor(tvLabelGender, R.color.main_blue)
             } else {
                 setStrokeColor(mcvGender, R.color.unuse)

--- a/app/src/main/java/umc/cozymate/ui/onboarding/OnboardingViewmodel.kt
+++ b/app/src/main/java/umc/cozymate/ui/onboarding/OnboardingViewmodel.kt
@@ -75,13 +75,13 @@ class OnboardingViewModel @Inject constructor(
             birthday = _birthday.value ?: "2001-01-01",
             persona = _persona.value ?: 0
         )
-        val token = "Bearer " + getToken()
+        val token = getToken()
         Log.d(TAG, "유저 정보: $memberInfo")
         Log.d(TAG, "토큰: $token")
 
         viewModelScope.launch {
             try {
-                val response = repository.signUp(token = token, memberInfo = memberInfo)
+                val response = repository.signUp(token = token!!, memberInfo = memberInfo)
                 if (response.isSuccessful) {
                     Log.d(TAG, "회원가입 api 응답 성공: ${response}")
                     if (response.body()!!.isSuccess) {

--- a/app/src/main/java/umc/cozymate/ui/onboarding/OnboardingViewmodel.kt
+++ b/app/src/main/java/umc/cozymate/ui/onboarding/OnboardingViewmodel.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 class OnboardingViewModel @Inject constructor(
     private val repository: MemberRepository,
     @ApplicationContext private val context: Context
-): ViewModel() {
+) : ViewModel() {
 
     private val TAG = this.javaClass.simpleName
 
@@ -72,7 +72,7 @@ class OnboardingViewModel @Inject constructor(
             name = _name.value ?: "unknown",
             nickname = _nickname.value ?: "unknown",
             gender = _gender.value ?: "MALE",
-            birthday =  _birthday.value ?: "2001-01-01",
+            birthday = _birthday.value ?: "2001-01-01",
             persona = _persona.value ?: 0
         )
         val token = "Bearer " + getToken()
@@ -81,19 +81,41 @@ class OnboardingViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
-                val response = repository.signUp(token=token, memberInfo=memberInfo)
+                val response = repository.signUp(token = token, memberInfo = memberInfo)
                 if (response.isSuccessful) {
-                    Log.d(TAG, "응답 성공: ${response.body()!!.result}")
+                    Log.d(TAG, "회원가입 api 응답 성공: ${response}")
                     if (response.body()!!.isSuccess) {
-                        Log.d(TAG, "회원가입 성공")
+                        Log.d(TAG, "회원가입 성공: ${response.body()!!.result}")
                     }
-                }
-                else {
-                    Log.d(TAG, "응답 실패: ${response}")
+                } else {
+                    Log.d(TAG, "회원가입 api 응답 실패: ${response}")
                 }
                 _signUpResponse.value = response
             } catch (e: Exception) {
                 Log.d(TAG, "api 요청 실패: ${e}")
+            }
+        }
+    }
+
+    fun nicknameCheck() {
+        val accessToken = getToken()
+
+        if (accessToken != null) {
+            viewModelScope.launch {
+                try {
+                    val response = repository.checkNickname(accessToken, nickname.value ?: "unknown")
+                    if (response.isSuccessful) {
+                        Log.d(TAG, "닉네임 유효성 체크 api 응답 성공: ${response}")
+                        if (response.body()!!.isSuccess) {
+                            Log.d(TAG, "닉네임 유효성 체크 성공: ${response.body()!!.result}")
+
+                        }
+                    } else {
+                        Log.d(TAG, "닉네임 유효성 체크 api 응답 실패: ${response}")
+                    }
+                } catch (e: Exception) {
+                    Log.d(TAG, "닉네임 유효성 체크 api 요청 실패: ${e}")
+                }
             }
         }
     }

--- a/app/src/main/java/umc/cozymate/ui/onboarding/OnboardingViewmodel.kt
+++ b/app/src/main/java/umc/cozymate/ui/onboarding/OnboardingViewmodel.kt
@@ -99,6 +99,7 @@ class OnboardingViewModel @Inject constructor(
 
     fun nicknameCheck() {
         val accessToken = getToken()
+        Log.d(TAG, "닉네임 유효성 체크 토큰 확인: $accessToken")
 
         if (accessToken != null) {
             viewModelScope.launch {

--- a/app/src/main/java/umc/cozymate/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/splash/SplashActivity.kt
@@ -9,7 +9,6 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.lifecycle.Observer
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.KakaoSdk
 import com.kakao.sdk.common.model.ClientError
@@ -80,11 +79,15 @@ class SplashActivity : AppCompatActivity() {
                     try {
                         splashViewModel.setTokenInfo(result.body()!!.result.tokenResponseDTO)
                         splashViewModel.saveToken()
+
+                        splashViewModel.memberCheck()
+                        splashViewModel.isMember.observe(this) { isMember ->
+                            if (isMember) goCozyHome()
+                            else goOnboarding()
+                        }
                     } catch (e: Exception) {
                         Log.d(TAG, "토큰 저장 실패: $e")
                     }
-
-                    isMember()
                 } else {
                     Toast.makeText(this, "로그인 실패", Toast.LENGTH_SHORT).show()
 
@@ -94,15 +97,6 @@ class SplashActivity : AppCompatActivity() {
                 goLoginFail()
             }
         }
-    }
-
-    private fun isMember() {
-        splashViewModel.memberCheck()
-
-        splashViewModel.isMember.observe(this, Observer { isMember ->
-            if (isMember) goCozyHome()
-            else goOnboarding()
-        })
     }
 
     private fun goCozyHome() {

--- a/app/src/main/java/umc/cozymate/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/splash/SplashActivity.kt
@@ -23,7 +23,7 @@ import umc.cozymate.ui.onboarding.OnboardingActivity
 
 // 로그인 >> 멤버 확인 Y >> 코지홈(MainActivity)으로 이동
 // 로그인 >> 멤버 확인 N >> 온보딩(OnboadrdingActivity)으로 이동
-// 로그인 N >> 로그인 실패(LoginFailActivity)로 이동
+// 로그인 N >> 로그인 실패(LoginFailActivity)로 이동 (<< 현재개발 시점에는 코지홈으로 이동하게 설정함)
 
 @AndroidEntryPoint
 class SplashActivity : AppCompatActivity() {
@@ -107,6 +107,8 @@ class SplashActivity : AppCompatActivity() {
 
     private fun goCozyHome() {
         val intent = Intent(this, MainActivity::class.java)
+        startActivity(intent)
+        finish()
     }
 
     private fun goOnboarding() {
@@ -116,7 +118,8 @@ class SplashActivity : AppCompatActivity() {
     }
 
     private fun goLoginFail() {
-        val intent = Intent(this, LoginFailActivity::class.java)
+        // val intent = Intent(this, LoginFailActivity::class.java)
+        val intent = Intent(this, MainActivity::class.java)
         startActivity(intent)
         finish()
     }

--- a/app/src/main/java/umc/cozymate/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/umc/cozymate/ui/splash/SplashViewModel.kt
@@ -37,6 +37,9 @@ class SplashViewModel @Inject constructor(
     private val _tokenInfo = MutableLiveData<TokenInfo>()
     val tokenInfo: LiveData<TokenInfo> get() = _tokenInfo
 
+    private val _isMember = MutableLiveData<Boolean>(false)
+    val isMember: LiveData<Boolean> get() = _isMember
+
     private val sharedPreferences = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
 
     fun setClientId(clientId: String) {
@@ -74,16 +77,65 @@ class SplashViewModel @Inject constructor(
                         )
                     )
                     if (response.isSuccessful) {
-                        Log.d(TAG, "응답 성공: ${response}")
+                        Log.d(TAG, "로그인 api 응답 성공: ${response}")
                         if (response.body()!!.isSuccess) {
                             Log.d(TAG, "로그인 성공: ${response.body()!!.result}")
                         }
                     } else {
-                        Log.d(TAG, "응답 실패: ${response}")
+                        Log.d(TAG, "로그인 응답 실패: ${response}")
+                        reissue()
                     }
                     _signInResponse.value = response
                 } catch (e: Exception) {
-                    Log.d(TAG, "api 요청 실패: ${e}")
+                    Log.d(TAG, "로그인 api 요청 실패: ${e}")
+                }
+            }
+        }
+    }
+
+    fun reissue() {
+        val refreshToken = _tokenInfo.value!!.refreshToken
+
+        if (refreshToken != null) {
+            viewModelScope.launch {
+                try {
+                    val response = repository.reissue(refreshToken)
+                    if (response.isSuccessful) {
+                        Log.d(TAG, "토큰 재발행 api 응답 성공: ${response}")
+                        if (response.body()!!.isSuccess) {
+                            Log.d(TAG, "토큰 재발행 성공: ${response.body()!!.result}")
+                            _tokenInfo.value!!.accessToken = response.body()!!.result.accessToken
+                            _tokenInfo.value!!.message = response.body()!!.result.message
+                            _tokenInfo.value!!.refreshToken = response.body()!!.result.message
+                        }
+                    } else {
+                        Log.d(TAG, "토큰 재발행 api 응답 실패: ${response}")
+                    }
+                } catch (e: Exception) {
+                    Log.d(TAG, "토큰 재발행 api 요청 실패: ${e}")
+                }
+            }
+        }
+    }
+
+    fun memberCheck(){
+        val accessToken = _tokenInfo.value!!.accessToken
+
+        if (accessToken != null) {
+            viewModelScope.launch {
+                try {
+                    val response = repository.getMemberInfo(accessToken)
+                    if (response.isSuccessful) {
+                        Log.d(TAG, "사용자 정보 조회 api 응답 성공: ${response}")
+                        if (response.body()!!.isSuccess) {
+                            Log.d(TAG, "사용자 정보 조회 성공: ${response.body()!!.result}")
+                            _isMember.value = true
+                        }
+                    } else {
+                        Log.d(TAG, "사용자 정보 조회 api 응답 실패: ${response}")
+                    }
+                } catch (e: Exception) {
+                    Log.d(TAG, "사용자 정보 조회 api 요청 실패: ${e}")
                 }
             }
         }

--- a/app/src/main/java/umc/cozymate/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/umc/cozymate/ui/splash/SplashViewModel.kt
@@ -59,8 +59,9 @@ class SplashViewModel @Inject constructor(
     }
 
     fun saveToken() {
-        Log.d(TAG, "토큰: ${_tokenInfo.value!!.accessToken}")
-        sharedPreferences.edit().putString("access_token", _tokenInfo.value!!.accessToken).apply()
+        Log.d(TAG, "코지메이트 어세스 토큰: ${_tokenInfo.value!!.accessToken}")
+        sharedPreferences.edit().putString("access_token", "Bearer " + _tokenInfo.value!!.accessToken).apply()
+        sharedPreferences.edit().putString("refresh_token", "Bearer " + _tokenInfo.value!!.refreshToken).apply()
     }
 
     fun signIn() {
@@ -94,7 +95,7 @@ class SplashViewModel @Inject constructor(
     }
 
     fun reissue() {
-        val refreshToken = _tokenInfo.value!!.refreshToken
+        val refreshToken = "Bearer " + _tokenInfo.value!!.refreshToken
 
         if (refreshToken != null) {
             viewModelScope.launch {
@@ -119,7 +120,7 @@ class SplashViewModel @Inject constructor(
     }
 
     fun memberCheck() {
-        val accessToken = _tokenInfo.value!!.accessToken
+        val accessToken = "Bearer " + _tokenInfo.value!!.accessToken
 
         if (accessToken != null) {
             viewModelScope.launch {

--- a/app/src/main/java/umc/cozymate/ui/splash/SplashViewModel.kt
+++ b/app/src/main/java/umc/cozymate/ui/splash/SplashViewModel.kt
@@ -118,7 +118,7 @@ class SplashViewModel @Inject constructor(
         }
     }
 
-    fun memberCheck(){
+    fun memberCheck() {
         val accessToken = _tokenInfo.value!!.accessToken
 
         if (accessToken != null) {

--- a/app/src/main/res/layout/fragment_onboarding_user_info.xml
+++ b/app/src/main/res/layout/fragment_onboarding_user_info.xml
@@ -80,7 +80,22 @@
                 android:textColorHint="@color/unuse_font"
                 android:textCursorDrawable="@color/main_blue" />
         </com.google.android.material.textfield.TextInputLayout>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <TextView
+        android:id="@+id/tv_alert_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="4dp"
+        android:text="이름은 한글로만 입력가능해요!"
+        android:textAppearance="@style/TextAppearance.App.10sp.Medium"
+        android:textColor="@color/red"
+        app:layout_constraintStart_toStartOf="@id/cl_onboarding_name"
+        app:layout_constraintTop_toBottomOf="@id/cl_onboarding_name"
+        android:visibility="gone"
+        />
 
     <!--닉네임-->
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -116,7 +131,7 @@
             app:boxStrokeErrorColor="@color/red"
             app:boxStrokeWidth="1dp"
             app:boxStrokeWidthFocused="1dp"
-            app:counterMaxLength="8"
+            app:counterMaxLength="9"
             app:errorTextColor="@color/red"
             app:hintEnabled="false"
             app:layout_constraintStart_toStartOf="parent"
@@ -137,6 +152,20 @@
                 android:textCursorDrawable="@color/black" />
         </com.google.android.material.textfield.TextInputLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <TextView
+        android:id="@+id/tv_alert_nickname"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="4dp"
+        android:text="닉네임은 2~8자인 한글, 영어, 숫자만 가능해요!"
+        android:textAppearance="@style/TextAppearance.App.10sp.Medium"
+        android:textColor="@color/red"
+        app:layout_constraintStart_toStartOf="@id/cl_onboarding_nickname"
+        app:layout_constraintTop_toBottomOf="@id/cl_onboarding_nickname"
+        android:visibility="gone"
+        />
 
     <!--성별-->
     <com.google.android.material.card.MaterialCardView
@@ -175,8 +204,8 @@
                 android:layout_marginStart="20dp"
                 android:layout_marginTop="6dp"
                 android:paddingBottom="16dp"
-                app:layout_constraintTop_toBottomOf="@id/tv_label_gender"
-                app:layout_constraintStart_toStartOf="parent">
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_label_gender">
 
                 <ImageView
                     android:id="@+id/iv_male"
@@ -205,10 +234,10 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="6dp"
-                android:paddingBottom="16dp"
                 android:paddingEnd="8dp"
-                app:layout_constraintTop_toBottomOf="@id/tv_label_gender"
-                app:layout_constraintStart_toEndOf="@id/radio_male">
+                android:paddingBottom="16dp"
+                app:layout_constraintStart_toEndOf="@id/radio_male"
+                app:layout_constraintTop_toBottomOf="@id/tv_label_gender">
 
                 <ImageView
                     android:id="@+id/iv_female"
@@ -284,9 +313,9 @@
                 android:layout_marginEnd="20dp"
                 android:layout_marginBottom="11.5dp"
                 android:src="@drawable/ic_dropdown"
-                app:layout_constraintTop_toTopOf="@id/tv_birth"
                 app:layout_constraintBottom_toBottomOf="@id/tv_birth"
-                app:layout_constraintEnd_toEndOf="parent" />
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_birth" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
## 📝작업 내용

#### SplashActivity.kt
- 카카오 로그인sdk 요청 > 유저 아이디값 get > 로그인 api 요청
- 로그인 성공 후 멤버인지 확인 > 멤버일 경우 바로 코지홈으로 이동
- 멤버가 아니라면 온보딩에서 회원가입
#### SplashViewModel.kt
- signIn() : 로그인 api 요청
- reissue() : 토큰 재발행 api 요청
- memberCheck() : 사용자 정보 조회 api 요청
- saveToken() : 토큰 정보를 spf에 저장합니다.
#### OnboardingUserInfoFragment.kt
- setupTextWatchers() : 이름과 닉네임 유효성을 검증하는 로직을 추가했습니다.
  - 닉네임 중복 체크의 경우, 사용자가 입력을 멈춘 후 0.5초 시간을 둔 뒤 api를 호출합니다.
- setClickColor() : 성별 선택이 남여 반대로 되고 있었는데 코드를 수정해서 해결했습니다.
#### OnboardingSelectingCharacterFragment.kt
- 확인 버튼 클릭시 회원가입 api 요청을 보내고 observeViewModel()에서 회원가입 응답 성공여부를 관찰합니다.
#### OnboardingViewmodel.kt
- joinMember() : 회원가입 api 요청
- nicknameCheck() : 닉네임 유효성 체크 api 요청

### 스크린샷 
이름/닉네임 체크 경고메시지
<img src="https://github.com/user-attachments/assets/0fad698b-7142-4ab6-8e1e-e99a96c40d51" width=300/>


## 💬꼭 확인해주세요!!
**전반적으로 쓰이는 유저정보는 "app_prefs"라는 이름의 SharedPreferences에 저장되어 있습니다. 특히 api 요청시 헤더에 필요한 어세스 토큰은 "access_token"이라는 이름의 string에 "Bearer {토큰}"으로 저장되어있으니 이부분 꼭 참고해주세요.**

### SplashViewModel.kt:61
```
fun saveToken() {
    Log.d(TAG, "코지메이트 어세스 토큰: ${_tokenInfo.value!!.accessToken}")
    sharedPreferences.edit().putString("access_token", "Bearer " + _tokenInfo.value!!.accessToken).apply()
    sharedPreferences.edit().putString("refresh_token", "Bearer " + _tokenInfo.value!!.refreshToken).apply()
}
```

### OnboadrindViewmode.ktl:50
```
fun saveUserInfo() {
    sharedPreferences.edit().putString("user_nickname", _nickname.value.toString()).apply()
    sharedPreferences.edit().putString("user_persona", _persona.value.toString()).apply()
    sharedPreferences.edit().putString("user_birthday", _birthday.value.toString()).apply()
    sharedPreferences.edit().putString("user_gender", _gender.value.toString()).apply()
}
```

### access token 사용 시:
ex - OnboardingViewmodel.kt:46
```
private val sharedPreferences = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)

fun getToken(): String? {
        return sharedPreferences.getString("access_token", null)
}
```

### 유저 정보 사용 시:
ex - OnboardingSummaryFragment.kt:42
```
private fun getPreference() {
    val spf = requireContext().getSharedPreferences("app_prefs", Context.MODE_PRIVATE)

    nickname = spf.getString("user_nickname", "No user found").toString()
    persona = spf.getInt("user_persona", 0)
}
```

