### PR TITLE
마이페이지 정보수정 화면 + 홈 화면 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
             android:name=".ui.my_page.MyFavoriteActivity"
             android:exported="false" />
         <activity
-            android:name=".ui.my_page.UpdateUserInfoActivity"
+            android:name=".ui.my_page.UpdateMyInfoActivity"
             android:exported="false" />
         <activity
             android:name=".ui.cozy_home.roommate.search_roommate.SearchRoommateActivity"
@@ -37,7 +37,7 @@
             android:name=".ui.cozy_home.room_detail.CozyRoomDetailInfoActivity"
             android:exported="false" />
         <activity
-            android:name=".ui.cozy_home.room_detail.UpdateCozyRoomDetailInfoActivity"
+            android:name=".ui.cozy_home.room_detail.UpdateMyRoomInfoActivity"
             android:exported="false" />
         <activity
             android:name=".ui.cozy_home.roommate.roommate_detail.CozyHomeRoommateDetailActivity"

--- a/app/src/main/java/umc/cozymate/data/api/MemberService.kt
+++ b/app/src/main/java/umc/cozymate/data/api/MemberService.kt
@@ -20,6 +20,7 @@ import umc.cozymate.data.model.response.member.MemberInfoResponse
 import umc.cozymate.data.model.response.member.ReissueResponse
 import umc.cozymate.data.model.response.member.SignInResponse
 import umc.cozymate.data.model.response.member.SignUpResponse
+import umc.cozymate.data.model.response.member.UpdateInfoCommonResponse
 import umc.cozymate.data.model.response.member.VerifyMailResponse
 import umc.cozymate.data.model.response.member.WithdrawResponse
 
@@ -109,4 +110,32 @@ interface MemberService {
         @Body request: VerifyMailRequest
     ): Response<VerifyMailResponse>
 
+    // 사용자 프로필 이미지 수정
+    @POST("/members/update-persona")
+    suspend fun updatePersona(
+        @Header("Authorization") accessToken: String,
+        @Query("persona") persona: Int
+    ): Response<UpdateInfoCommonResponse>
+
+    // 사용자 닉네임 수정
+    @POST("/members/update-nickname")
+    suspend fun updateNickname(
+        @Header("Authorization") accessToken: String,
+        @Query("nickname") nickname: String
+    ): Response<UpdateInfoCommonResponse>
+
+    // 사용자 프로필 이미지 수정
+    @POST("/members/update-majorName")
+    suspend fun updateMajorName(
+        @Header("Authorization") accessToken: String,
+        @Query("majorName") majorName: String
+    ): Response<UpdateInfoCommonResponse>
+
+    // 사용자 생일 수정
+    // yyyy-MM-dd 형식
+    @POST("/members/update-birthday")
+    suspend fun updateBirthday(
+        @Header("Authorization") accessToken: String,
+        @Query("localDate") localDate: String
+    ): Response<UpdateInfoCommonResponse>
 }

--- a/app/src/main/java/umc/cozymate/data/api/MemberStatPreferenceService.kt
+++ b/app/src/main/java/umc/cozymate/data/api/MemberStatPreferenceService.kt
@@ -9,6 +9,7 @@ import retrofit2.http.PUT
 import umc.cozymate.data.model.entity.PreferenceList
 import umc.cozymate.data.model.response.member.stat.GetMyPreferenceResponse
 import umc.cozymate.data.model.response.member.stat.PostMyPreferenceResponse
+import umc.cozymate.data.model.response.member.stat.UpdatePreferenceResponse
 
 interface MemberStatPreferenceService {
 
@@ -30,6 +31,6 @@ interface MemberStatPreferenceService {
     suspend fun updateMyPreference(
         @Header("Authorization") accessToken: String,
         @Body preferenceList: PreferenceList
-    ) : Response<PostMyPreferenceResponse>
+    ) : Response<UpdatePreferenceResponse>
 
 }

--- a/app/src/main/java/umc/cozymate/data/model/response/member/UpdateInfoCommonResponse.kt
+++ b/app/src/main/java/umc/cozymate/data/model/response/member/UpdateInfoCommonResponse.kt
@@ -1,0 +1,17 @@
+package umc.cozymate.data.model.response.member
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateInfoCommonResponse(
+    @SerialName("code")
+    val code: String,
+    @SerialName("isSuccess")
+    val isSuccess: Boolean,
+    @SerialName("message")
+    val message: String,
+    @SerialName("result")
+    val result: Boolean
+)

--- a/app/src/main/java/umc/cozymate/data/model/response/member/stat/UpdatePreferenceResponse.kt
+++ b/app/src/main/java/umc/cozymate/data/model/response/member/stat/UpdatePreferenceResponse.kt
@@ -1,0 +1,17 @@
+package umc.cozymate.data.model.response.member.stat
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdatePreferenceResponse(
+    @SerialName("code")
+    val code: String,
+    @SerialName("isSuccess")
+    val isSuccess: Boolean,
+    @SerialName("message")
+    val message: String,
+    @SerialName("result")
+    val result: Int
+)

--- a/app/src/main/java/umc/cozymate/data/repository/repository/MemberRepository.kt
+++ b/app/src/main/java/umc/cozymate/data/repository/repository/MemberRepository.kt
@@ -14,6 +14,7 @@ import umc.cozymate.data.model.response.member.MemberInfoResponse
 import umc.cozymate.data.model.response.member.ReissueResponse
 import umc.cozymate.data.model.response.member.SignInResponse
 import umc.cozymate.data.model.response.member.SignUpResponse
+import umc.cozymate.data.model.response.member.UpdateInfoCommonResponse
 import umc.cozymate.data.model.response.member.VerifyMailResponse
 import umc.cozymate.data.model.response.member.WithdrawResponse
 
@@ -45,4 +46,11 @@ interface MemberRepository {
 
     suspend fun verifyMail(accessToken: String, request: VerifyMailRequest): Response<VerifyMailResponse>
 
+    suspend fun updatePersona(accessToken: String, persona: Int): Response<UpdateInfoCommonResponse>
+
+    suspend fun updateNickname(accessToken: String, nickname: String): Response<UpdateInfoCommonResponse>
+
+    suspend fun updateMajorName(accessToken: String, majorName: String): Response<UpdateInfoCommonResponse>
+
+    suspend fun updateBirthday(accessToken: String, localDate: String): Response<UpdateInfoCommonResponse>
 }

--- a/app/src/main/java/umc/cozymate/data/repository/repository/MemberStatPreferenceRepository.kt
+++ b/app/src/main/java/umc/cozymate/data/repository/repository/MemberStatPreferenceRepository.kt
@@ -4,6 +4,7 @@ import retrofit2.Response
 import umc.cozymate.data.model.entity.PreferenceList
 import umc.cozymate.data.model.response.member.stat.GetMyPreferenceResponse
 import umc.cozymate.data.model.response.member.stat.PostMyPreferenceResponse
+import umc.cozymate.data.model.response.member.stat.UpdatePreferenceResponse
 
 interface MemberStatPreferenceRepository {
 
@@ -11,6 +12,6 @@ interface MemberStatPreferenceRepository {
 
     suspend fun postMyPreference(accessToken: String, preferenceList: PreferenceList): Response<PostMyPreferenceResponse>
 
-    suspend fun updateMyPreference(accessToken: String, preferenceList: PreferenceList): Response<PostMyPreferenceResponse>
+    suspend fun updateMyPreference(accessToken: String, preferenceList: PreferenceList): Response<UpdatePreferenceResponse>
 
 }

--- a/app/src/main/java/umc/cozymate/data/repository/repositoryImpl/MemberRepositoryImpl.kt
+++ b/app/src/main/java/umc/cozymate/data/repository/repositoryImpl/MemberRepositoryImpl.kt
@@ -15,6 +15,7 @@ import umc.cozymate.data.model.response.member.MemberInfoResponse
 import umc.cozymate.data.model.response.member.ReissueResponse
 import umc.cozymate.data.model.response.member.SignInResponse
 import umc.cozymate.data.model.response.member.SignUpResponse
+import umc.cozymate.data.model.response.member.UpdateInfoCommonResponse
 import umc.cozymate.data.model.response.member.VerifyMailResponse
 import umc.cozymate.data.model.response.member.WithdrawResponse
 import umc.cozymate.data.repository.repository.MemberRepository
@@ -80,5 +81,33 @@ class MemberRepositoryImpl @Inject constructor(
         request: VerifyMailRequest
     ): Response<VerifyMailResponse> {
         return api.verifyMail(accessToken, request)
+    }
+
+    override suspend fun updatePersona(
+        accessToken: String,
+        persona: Int
+    ): Response<UpdateInfoCommonResponse> {
+        return api.updatePersona(accessToken, persona)
+    }
+
+    override suspend fun updateNickname(
+        accessToken: String,
+        nickname: String
+    ): Response<UpdateInfoCommonResponse> {
+        return api.updateNickname(accessToken, nickname)
+    }
+
+    override suspend fun updateMajorName(
+        accessToken: String,
+        majorName: String
+    ): Response<UpdateInfoCommonResponse> {
+        return api.updateMajorName(accessToken, majorName)
+    }
+
+    override suspend fun updateBirthday(
+        accessToken: String,
+        localDate: String
+    ): Response<UpdateInfoCommonResponse> {
+        return api.updateBirthday(accessToken, localDate)
     }
 }

--- a/app/src/main/java/umc/cozymate/data/repository/repositoryImpl/MemberStatPreferenceRepositoryImpl.kt
+++ b/app/src/main/java/umc/cozymate/data/repository/repositoryImpl/MemberStatPreferenceRepositoryImpl.kt
@@ -5,6 +5,7 @@ import umc.cozymate.data.api.MemberStatPreferenceService
 import umc.cozymate.data.model.entity.PreferenceList
 import umc.cozymate.data.model.response.member.stat.GetMyPreferenceResponse
 import umc.cozymate.data.model.response.member.stat.PostMyPreferenceResponse
+import umc.cozymate.data.model.response.member.stat.UpdatePreferenceResponse
 import umc.cozymate.data.repository.repository.MemberStatPreferenceRepository
 import javax.inject.Inject
 
@@ -26,7 +27,7 @@ class MemberStatPreferenceRepositoryImpl @Inject constructor(
     override suspend fun updateMyPreference(
         accessToken: String,
         preferenceList: PreferenceList
-    ): Response<PostMyPreferenceResponse> {
+    ): Response<UpdatePreferenceResponse> {
         return api.updateMyPreference(accessToken, preferenceList)
     }
 }

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/room/making_room/MakingPrivateRoomFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/room/making_room/MakingPrivateRoomFragment.kt
@@ -128,7 +128,8 @@ class MakingPrivateRoomFragment : Fragment() {
 
                         !pattern.matches(input) -> {
                             tvAlertName.visibility = View.VISIBLE
-                            tvAlertName.text = "방이름은 최대 12글자로 한글, 영어, 숫자 및 공백만 입력해주세요!"
+                            tvAlertName.text = "방이름은 최대 12글자로 한글, 영어, 숫자 및 공백만 입력해주세요!\n" +
+                                    "단 공백은 처음이나 끝에 올 수 없습니다."
                             tilRoomName.isErrorEnabled = true
                         }
 

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/room/making_room/MakingPrivateRoomFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/room/making_room/MakingPrivateRoomFragment.kt
@@ -117,25 +117,37 @@ class MakingPrivateRoomFragment : Fragment() {
 
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                     val input = s.toString()
-                    if (input.length > 12) {
-                        tvAlertName.visibility = View.VISIBLE
-                        tvAlertName.text = "방이름은 최대 12글자만 가능해요!"
-                        tilRoomName.isErrorEnabled = true
-                    } else {
-                        tvAlertName.visibility = View.GONE
-                        roomName = etRoomName.text.toString()
-                        tilRoomName.isErrorEnabled = false
-                        viewModel.setNickname(roomName)
-                        // Debounce 작업: 사용자가 입력을 멈춘 후 일정 시간 후에 중복 체크 API 호출
-                        debounceJob?.cancel()
-                        debounceJob = viewModel.viewModelScope.launch {
-                            delay(500L) // 500ms 대기
-                            viewModel.setNickname(input)
-                            viewModel.roomNameCheck() // API 호출
-                            observeRoomNameValid()
+                    val pattern = "^(?=.*[가-힣a-zA-Z0-9])[가-힣a-zA-Z0-9 ]{1,12}(?<! )$".toRegex()
+                    val containsSeparatedHangul = input.any { it in 'ㄱ'..'ㅎ' || it in 'ㅏ'..'ㅣ' }
+                    when {
+                        containsSeparatedHangul -> {
+                            tvAlertName.visibility = View.VISIBLE
+                            tvAlertName.text = "방이름은 분리된 한글(자음, 모음)이 포함되면 안됩니다!"
+                            tilRoomName.isErrorEnabled = true
                         }
-                        // 다음 버튼 상태 확인
-                        updateNextButtonState()
+
+                        !pattern.matches(input) -> {
+                            tvAlertName.visibility = View.VISIBLE
+                            tvAlertName.text = "방이름은 최대 12글자로 한글, 영어, 숫자 및 공백만 입력해주세요!"
+                            tilRoomName.isErrorEnabled = true
+                        }
+
+                        else -> {
+                            tvAlertName.visibility = View.GONE
+                            roomName = etRoomName.text.toString()
+                            tilRoomName.isErrorEnabled = false
+                            viewModel.setNickname(roomName)
+                            // Debounce 작업: 사용자가 입력을 멈춘 후 일정 시간 후에 중복 체크 API 호출
+                            debounceJob?.cancel()
+                            debounceJob = viewModel.viewModelScope.launch {
+                                delay(500L) // 500ms 대기
+                                viewModel.setNickname(input)
+                                viewModel.roomNameCheck() // API 호출
+                                observeRoomNameValid()
+                            }
+                            // 다음 버튼 상태 확인
+                            updateNextButtonState()
+                        }
                     }
                 }
 
@@ -188,7 +200,10 @@ class MakingPrivateRoomFragment : Fragment() {
         }
         // 방 생성 결과를 관찰하여 성공 시 다음 화면으로 전환
         viewModel.privateRoomCreationResult.observe(viewLifecycleOwner) { result ->
-            (activity as? MakingPrivateRoomActivity)?.loadGivingInviteCodeFragment(result.result.persona, result.result.inviteCode)
+            (activity as? MakingPrivateRoomActivity)?.loadGivingInviteCodeFragment(
+                result.result.persona,
+                result.result.inviteCode
+            )
         }
         // 에러 응답도 추가로 처리할 수 있음 >> TODO : 팝업 띄우기
         viewModel.errorResponse.observe(viewLifecycleOwner) { error ->

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/room/making_room/MakingPublicRoomFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/room/making_room/MakingPublicRoomFragment.kt
@@ -209,27 +209,45 @@ class MakingPublicRoomFragment : Fragment() {
         with(binding) {
             // 방 글자수
             etRoomName.addTextChangedListener(object : TextWatcher {
-                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+                override fun beforeTextChanged(
+                    s: CharSequence?,
+                    start: Int,
+                    count: Int,
+                    after: Int
+                ) {
+                }
 
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                     val input = s.toString()
-                    if (input.length > 12) {
-                        tvAlertName.visibility = View.VISIBLE
-                        tvAlertName.text = "방이름은 최대 12글자만 가능해요!"
-                    } else {
-                        tvAlertName.visibility = View.GONE
-                        roomName = etRoomName.text.toString()
-                        viewModel.setNickname(roomName)
-                        // Debounce 작업: 사용자가 입력을 멈춘 후 일정 시간 후에 중복 체크 API 호출
-                        debounceJob?.cancel()
-                        debounceJob = viewModel.viewModelScope.launch {
-                            delay(1000L) // 1000ms 대기
-                            viewModel.setNickname(input)
-                            viewModel.roomNameCheck() // API 호출
-                            observeRoomNameValid()
+                    val pattern = "^(?=.*[가-힣a-zA-Z0-9])[가-힣a-zA-Z0-9 ]{1,12}(?<! )$".toRegex()
+                    val containsSeparatedHangul = input.any { it in 'ㄱ'..'ㅎ' || it in 'ㅏ'..'ㅣ' }
+                    when {
+                        containsSeparatedHangul -> {
+                            tvAlertName.visibility = View.VISIBLE
+                            tvAlertName.text = "방이름은 분리된 한글(자음, 모음)이 포함되면 안됩니다!"
+                            tilRoomName.isErrorEnabled = true
                         }
-                        // 다음 버튼 상태 확인
-                        updateNextButtonState()
+
+                        !pattern.matches(input) -> {
+                            tvAlertName.visibility = View.VISIBLE
+                            tvAlertName.text = "방이름은 최대 12글자로 한글, 영어, 숫자 및 공백만 입력해주세요!"
+                        }
+
+                        else -> {
+                            tvAlertName.visibility = View.GONE
+                            roomName = etRoomName.text.toString()
+                            viewModel.setNickname(roomName)
+                            // Debounce 작업: 사용자가 입력을 멈춘 후 일정 시간 후에 중복 체크 API 호출
+                            debounceJob?.cancel()
+                            debounceJob = viewModel.viewModelScope.launch {
+                                delay(1000L) // 1000ms 대기
+                                viewModel.setNickname(input)
+                                viewModel.roomNameCheck() // API 호출
+                                observeRoomNameValid()
+                            }
+                            // 다음 버튼 상태 확인
+                            updateNextButtonState()
+                        }
                     }
                 }
 

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/room/making_room/MakingPublicRoomFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/room/making_room/MakingPublicRoomFragment.kt
@@ -230,7 +230,9 @@ class MakingPublicRoomFragment : Fragment() {
 
                         !pattern.matches(input) -> {
                             tvAlertName.visibility = View.VISIBLE
-                            tvAlertName.text = "방이름은 최대 12글자로 한글, 영어, 숫자 및 공백만 입력해주세요!"
+                            tvAlertName.text = "방이름은 최대 12글자로 한글, 영어, 숫자 및 공백만 입력해주세요!\n" +
+                                    "단 공백은 처음이나 끝에 올 수 없습니다."
+                            tilRoomName.isErrorEnabled = true
                         }
 
                         else -> {

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/room/received_request/MyReceivedRequestComponent.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/room/received_request/MyReceivedRequestComponent.kt
@@ -52,11 +52,13 @@ class MyReceivedRequestComponent : Fragment() {
         viewModel.PendingMemberResponse.observe(viewLifecycleOwner) { response ->
             val roomList = response?.result ?: emptyList()
             if (roomList.isNotEmpty()) {
+                binding.tvRequestNum.text = "${roomList.size}개의"
                 binding.clComponent.visibility = View.VISIBLE
                 binding.clEmptyRoommate.visibility = View.GONE
                 binding.rvMyReceived.visibility = View.VISIBLE
                 adapter.submitList(roomList)
             } else {
+                binding.tvRequestNum.text = "0개의"
                 binding.clComponent.visibility = View.VISIBLE
                 binding.clEmptyRoommate.visibility = View.VISIBLE
                 binding.clEmptyRoommate.isEnabled = true

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/room/room_recommend/RoomRecommendComponent.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/room/room_recommend/RoomRecommendComponent.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.launch
 import umc.cozymate.databinding.FragmentRoomRecommendComponentBinding
 import umc.cozymate.ui.cozy_home.room.room_detail.RoomDetailActivity
 import umc.cozymate.ui.cozy_home.room_detail.CozyRoomDetailInfoActivity
+import umc.cozymate.ui.cozy_home.roommate.roommate_recommend.RoommateRecommendViewModel
 import umc.cozymate.ui.viewmodel.CozyHomeViewModel
 
 @AndroidEntryPoint
@@ -21,8 +22,9 @@ class RoomRecommendComponent : Fragment() {
     private var _binding: FragmentRoomRecommendComponentBinding? = null
     private val binding get() = _binding!!
     private val viewModel: CozyHomeViewModel by viewModels()
+    private val roommateViewModel: RoommateRecommendViewModel by viewModels()
     private var nickname: String = ""
-    private var prefList: List<String> = mutableListOf()
+    private var isLifestyleExist = false
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -37,7 +39,12 @@ class RoomRecommendComponent : Fragment() {
         nickname = viewModel.getNickname().toString()
         binding.tvName.text = "${nickname}님과"
         viewLifecycleOwner.lifecycleScope.launch {
+            roommateViewModel.fetchRoommateListByEquality()
             viewModel.fetchRecommendedRoomList()
+        }
+        roommateViewModel.roommateList.observe(viewLifecycleOwner) { list ->
+            if (list.isNullOrEmpty()) isLifestyleExist = false
+            else isLifestyleExist = true
         }
         viewModel.roomList.observe(viewLifecycleOwner) { roomList ->
             if (roomList.isNullOrEmpty()) {
@@ -47,7 +54,7 @@ class RoomRecommendComponent : Fragment() {
                 val dotsIndicator = binding.dotsIndicator
                 val viewPager = binding.vpRoom
                 // 클릭 시 방 상세 페이지로 room id 넘겨줌
-                val adapter = RoomRecommendVPAdapter(roomList, prefList) { roomId ->
+                val adapter = RoomRecommendVPAdapter(roomList, isLifestyleExist) { roomId ->
                     val intent = Intent(requireContext(), CozyRoomDetailInfoActivity::class.java).apply {
                         putExtra(CozyRoomDetailInfoActivity.ARG_ROOM_ID, roomId)
                     }
@@ -62,16 +69,5 @@ class RoomRecommendComponent : Fragment() {
             val intent = Intent(requireContext(), RoomDetailActivity::class.java)
             startActivity(intent)
         }
-    }
-
-    // sharedpreference에서 데이터 받아오기
-    private fun getPreference() {
-        /*prefList = arrayListOf(
-            spf.getString("pref_1", "No pref found").toString(),
-            spf.getString("pref_2", "No pref found").toString(),
-            spf.getString("pref_3", "No pref found").toString(),
-            spf.getString("pref_4", "No pref found").toString(),
-        )
-        Log.d(TAG, "prefList: $prefList")*/
     }
 }

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/room/room_recommend/RoomRecommendComponent.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/room/room_recommend/RoomRecommendComponent.kt
@@ -35,7 +35,7 @@ class RoomRecommendComponent : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         nickname = viewModel.getNickname().toString()
-        binding.tvName.text = "${nickname}님이"
+        binding.tvName.text = "${nickname}님과"
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.fetchRecommendedRoomList()
         }

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/room/room_recommend/RoomRecommendVPAdapter.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/room/room_recommend/RoomRecommendVPAdapter.kt
@@ -8,7 +8,7 @@ import umc.cozymate.databinding.VpItemRoomRecommendBinding
 
 class RoomRecommendVPAdapter(
     private var items: List<GetRecommendedRoomListResponse.Result.Result>,
-    private val prefs: List<String>,
+    private val isLifestyleExist: Boolean,
     private val onClick: (roomId: Int) -> Unit // 클릭 이벤트 핸들러 추가)
 ): RecyclerView.Adapter<RoomRecommendVPViewHolder>() {
 
@@ -27,7 +27,7 @@ class RoomRecommendVPAdapter(
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.MATCH_PARENT
         )
-        return RoomRecommendVPViewHolder(binding, prefs)
+        return RoomRecommendVPViewHolder(binding, isLifestyleExist)
     }
 
     override fun onBindViewHolder(holder: RoomRecommendVPViewHolder, position: Int) {

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/room/room_recommend/RoomRecommendVPViewHolder.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/room/room_recommend/RoomRecommendVPViewHolder.kt
@@ -16,7 +16,7 @@ class RoomRecommendVPViewHolder(
         with(binding) {
             tvRoomName.text = item.name
             tvMatchRate.text = "${item.equality}%"
-            tvMemberNumber.text = "${item.numOfArrival} / ${item.maxMateNum}"
+            tvMemberNumber.text = "${item.numOfArrival} / ${item.maxMateNum}명"
             when (item.hashtags.size) {
                 0 -> {
                     tvHashtag1.visibility = View.INVISIBLE

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/room/room_recommend/RoomRecommendVPViewHolder.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/room/room_recommend/RoomRecommendVPViewHolder.kt
@@ -8,7 +8,7 @@ import umc.cozymate.databinding.VpItemRoomRecommendBinding
 
 class RoomRecommendVPViewHolder(
     private val binding: VpItemRoomRecommendBinding,
-    private val myPrefList: List<String>
+    private val isLifestyleExist: Boolean
 ) :
     RecyclerView.ViewHolder(binding.root) {
 
@@ -51,6 +51,10 @@ class RoomRecommendVPViewHolder(
                     0 -> {
                         tvCriteriaContent1.text = "0명 일치"
                         ivCriteriaIcon1.setImageResource(pref1.redDrawable)
+                        if (isLifestyleExist == false) {
+                            tvCriteriaContent1.text = "???"
+                            ivCriteriaIcon1.setImageResource(pref1.grayDrawable)
+                        }
                     }
 
                     item.numOfArrival -> {
@@ -66,14 +70,17 @@ class RoomRecommendVPViewHolder(
             }
 
             // 선호항목 2
-            val pref2 =
-                Preference.entries.find { it.pref == item.preferenceMatchCountList[1].preferenceName }
+            val pref2 = Preference.entries.find { it.pref == item.preferenceMatchCountList[1].preferenceName }
             if (pref2 != null) {
                 tvCriteria2.text = pref2.displayName
                 when (item.preferenceMatchCountList[1].count) {
                     0 -> {
                         tvCriteriaContent2.text = "0명 일치"
                         ivCrieteriaIcon2.setImageResource(pref2.redDrawable)
+                        if (isLifestyleExist == false) {
+                            tvCriteriaContent2.text = "???"
+                            ivCrieteriaIcon2.setImageResource(pref2.grayDrawable)
+                        }
                     }
 
                     item.numOfArrival -> {
@@ -89,14 +96,17 @@ class RoomRecommendVPViewHolder(
             }
 
             // 선호항목 3
-            val pref3 =
-                Preference.entries.find { it.pref == item.preferenceMatchCountList[2].preferenceName }
+            val pref3 = Preference.entries.find { it.pref == item.preferenceMatchCountList[2].preferenceName }
             if (pref3 != null) {
                 tvCriteria3.text = pref3.displayName
                 when (item.preferenceMatchCountList[2].count) {
                     0 -> {
                         tvCriteriaContent3.text = "0명 일치"
                         ivCrieteriaIcon3.setImageResource(pref3.redDrawable)
+                        if (isLifestyleExist == false) {
+                            tvCriteriaContent3.text = "???"
+                            ivCrieteriaIcon3.setImageResource(pref3.grayDrawable)
+                        }
                     }
 
                     item.numOfArrival -> {
@@ -113,14 +123,17 @@ class RoomRecommendVPViewHolder(
             }
 
             // 선호항목 4
-            val pref4 =
-                Preference.entries.find { it.pref == item.preferenceMatchCountList[3].preferenceName }
+            val pref4 = Preference.entries.find { it.pref == item.preferenceMatchCountList[3].preferenceName }
             if (pref4 != null) {
                 tvCriteria4.text = pref4.displayName
                 when (item.preferenceMatchCountList[3].count) {
                     0 -> {
                         tvCriteriaContent4.text = "0명 일치"
                         ivCrieteriaIcon4.setImageResource(pref4.redDrawable)
+                        if (isLifestyleExist == false) {
+                            tvCriteriaContent4.text = "???"
+                            ivCrieteriaIcon4.setImageResource(pref4.grayDrawable)
+                        }
                     }
 
                     item.numOfArrival -> {

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/room/sent_request/MySentRequestComponent.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/room/sent_request/MySentRequestComponent.kt
@@ -56,6 +56,7 @@ class MySentRequestComponent : Fragment() {
                 binding.rvMySent.visibility = View.VISIBLE
                 adapter.submitList(roomList)
             } else {
+                binding.clComponent.visibility = View.GONE
                 binding.tvEmptyRoom.visibility = View.VISIBLE
                 binding.rvMySent.visibility = View.GONE
             }

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/roommate/roommate_detail/CozyHomeRoommateDetailActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/roommate/roommate_detail/CozyHomeRoommateDetailActivity.kt
@@ -1,21 +1,31 @@
 package umc.cozymate.ui.cozy_home.roommate.roommate_detail
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import umc.cozymate.R
+import umc.cozymate.databinding.ActivityCozyHomeRoommateDetailBinding
+import umc.cozymate.ui.cozy_home.roommate.search_roommate.SearchRoommateActivity
 
 class CozyHomeRoommateDetailActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityCozyHomeRoommateDetailBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContentView(R.layout.activity_cozy_home_roommate_detail)
+        binding = ActivityCozyHomeRoommateDetailBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
+        }
+        // 사용자 검색으로 이동
+        binding.lyRoomMateSearch.setOnClickListener {
+            val intent = Intent(this, SearchRoommateActivity::class.java)
+            startActivity(intent)
         }
     }
 }

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/roommate/roommate_recommend/RoommateRecommendComponent.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/roommate/roommate_recommend/RoommateRecommendComponent.kt
@@ -11,7 +11,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import umc.cozymate.databinding.FragmentRoommateRecommendComponentBinding
-import umc.cozymate.ui.cozy_home.roommate.search_roommate.SearchRoommateActivity
+import umc.cozymate.ui.cozy_home.roommate.roommate_detail.CozyHomeRoommateDetailActivity
 
 @AndroidEntryPoint
 class RoommateRecommendComponent : Fragment() {
@@ -59,7 +59,7 @@ class RoommateRecommendComponent : Fragment() {
         }
         // 룸메이트 더보기
         binding.llMore.setOnClickListener {
-            val intent = Intent(requireContext(), SearchRoommateActivity::class.java)
+            val intent = Intent(requireContext(), CozyHomeRoommateDetailActivity::class.java)
             startActivity(intent)
         }
     }

--- a/app/src/main/java/umc/cozymate/ui/my_page/FavoriteRoomRVAdapter.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/FavoriteRoomRVAdapter.kt
@@ -9,7 +9,8 @@ import umc.cozymate.data.model.response.favorites.GetFavoritesRoomsResponse
 import umc.cozymate.databinding.VpItemRoomRecommendBinding
 
 class FavoriteRoomRVAdapter(
-    private var items: List<GetFavoritesRoomsResponse.Result>
+    private var items: List<GetFavoritesRoomsResponse.Result>,
+    private val onItemClick: (Int) -> Unit
 ) : RecyclerView.Adapter<FavoriteRoomRVAdapter.RoomViewHolder>() {
 
     class RoomViewHolder(private val binding: VpItemRoomRecommendBinding) :
@@ -132,6 +133,10 @@ class FavoriteRoomRVAdapter(
 
     override fun onBindViewHolder(holder: RoomViewHolder, position: Int) {
         holder.bind(items[position])
+        // 아이템 클릭 시 roomId를 콜백으로 전달
+        holder.itemView.setOnClickListener {
+            onItemClick(items[position].roomId)
+        }
     }
 
     fun submitList(list: List<GetFavoritesRoomsResponse.Result>) {

--- a/app/src/main/java/umc/cozymate/ui/my_page/FavoriteRoommateRVAdapter.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/FavoriteRoommateRVAdapter.kt
@@ -8,7 +8,8 @@ import umc.cozymate.data.model.response.favorites.GetFavoritesMembersResponse
 import umc.cozymate.databinding.VpItemRoommateRecommendBinding
 
 class FavoriteRoommateRVAdapter(
-    private var items: List<GetFavoritesMembersResponse.Result>
+    private var items: List<GetFavoritesMembersResponse.Result>,
+    private val onItemClick: (Int) -> Unit
 ) : RecyclerView.Adapter<FavoriteRoommateRVAdapter.RoommateViewHolder>() {
 
     class RoommateViewHolder(private val binding: VpItemRoommateRecommendBinding) :
@@ -150,6 +151,10 @@ class FavoriteRoommateRVAdapter(
 
     override fun onBindViewHolder(holder: RoommateViewHolder, position: Int) {
         holder.bind(items[position])
+        // 아이템 클릭 시 roomId를 콜백으로 전달
+        holder.itemView.setOnClickListener {
+            onItemClick(items[position].favoriteId)
+        }
     }
 
     fun submitList(list: List<GetFavoritesMembersResponse.Result>) {

--- a/app/src/main/java/umc/cozymate/ui/my_page/MyFavoriteActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/MyFavoriteActivity.kt
@@ -1,5 +1,6 @@
 package umc.cozymate.ui.my_page
 
+import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.view.View
@@ -12,6 +13,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import umc.cozymate.databinding.ActivityMyFavoriteBinding
+import umc.cozymate.ui.MainActivity
+import umc.cozymate.ui.cozy_home.room_detail.CozyRoomDetailInfoActivity
+import umc.cozymate.ui.cozy_home.roommate.roommate_detail.CozyHomeRoommateDetailActivity
+import umc.cozymate.ui.pop_up.OneButtonPopup
+import umc.cozymate.ui.pop_up.PopupClick
 import umc.cozymate.ui.viewmodel.FavoriteViewModel
 import umc.cozymate.util.StatusBarUtil
 
@@ -37,10 +43,28 @@ class MyFavoriteActivity : AppCompatActivity() {
     }
 
     fun setupRVAdapter() {
-        membersAdapter = FavoriteRoommateRVAdapter(emptyList())
+        membersAdapter = FavoriteRoommateRVAdapter(emptyList()) { memberId ->
+            val intent = Intent(this, CozyHomeRoommateDetailActivity::class.java).apply {
+                putExtra("member_id", memberId) // 멤버 아이디 전달
+            }
+            try {
+                startActivity(intent)
+            } catch (e: Exception) {
+                showNoMemberPopup()
+            }
+        }
         binding.rvFavoriteRoommate.adapter = membersAdapter
         binding.rvFavoriteRoommate.layoutManager = LinearLayoutManager(this)
-        roomsAdapter = FavoriteRoomRVAdapter(emptyList())
+        roomsAdapter = FavoriteRoomRVAdapter(emptyList()) { roomId ->
+            val intent = Intent(this, CozyRoomDetailInfoActivity::class.java).apply {
+                putExtra(CozyRoomDetailInfoActivity.ARG_ROOM_ID, roomId) // 방 아이디 전달
+            }
+            try {
+                startActivity(intent)
+            } catch (e: Exception) {
+                showNoRooomPopup()
+            }
+        }
         binding.rvFavoriteRoom.adapter = roomsAdapter
         binding.rvFavoriteRoom.layoutManager = LinearLayoutManager(this)
     }
@@ -116,5 +140,35 @@ class MyFavoriteActivity : AppCompatActivity() {
         } else {
             binding.progressBar.visibility = View.GONE
         }
+    }
+
+    fun showNoRooomPopup() {
+        val text = listOf("존재하지 않는 방이에요", "", "확인")
+        // 팝업 객체 생성
+        val dialog = OneButtonPopup(text, object : PopupClick {
+            override fun clickFunction() {
+                val intent = Intent(baseContext, MainActivity::class.java)
+                startActivity(intent)
+                finish()
+            }
+        }, false)
+
+        // 팝업 띄우기
+        dialog.show(supportFragmentManager, "NoRoomPopup")
+    }
+
+    fun showNoMemberPopup() {
+        val text = listOf("존재하지 않는 사용자에요", "", "확인")
+        // 팝업 객체 생성
+        val dialog = OneButtonPopup(text, object : PopupClick {
+            override fun clickFunction() {
+                val intent = Intent(baseContext, MainActivity::class.java)
+                startActivity(intent)
+                finish()
+            }
+        }, false)
+
+        // 팝업 띄우기
+        dialog.show(supportFragmentManager, "NoMemberPopup")
     }
 }

--- a/app/src/main/java/umc/cozymate/ui/my_page/MyPageFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/MyPageFragment.kt
@@ -11,7 +11,9 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import umc.cozymate.R
 import umc.cozymate.databinding.FragmentMypageBinding
-import umc.cozymate.ui.cozy_home.room_detail.UpdateCozyRoomDetailInfoActivity
+import umc.cozymate.ui.cozy_home.room_detail.UpdateMyRoomInfoActivity
+import umc.cozymate.ui.pop_up.OneButtonPopup
+import umc.cozymate.ui.pop_up.PopupClick
 import umc.cozymate.ui.splash.SplashActivity
 import umc.cozymate.ui.university_certification.UniversityCertificationFragment
 import umc.cozymate.ui.viewmodel.InquiryViewModel
@@ -42,6 +44,10 @@ class MyPageFragment : Fragment() {
         binding.tvMypageUserName.text = nickname
         binding.ivMypageCharacter.setImageResource(initCharactor())
         binding.tvCozyroom.text = roomname
+        binding.layoutMyinfo.setOnClickListener {
+            val intent = Intent(activity, UpdateMyInfoActivity::class.java)
+            startActivity(intent)
+        }
         binding.layoutCozyroom.setOnClickListener {
             if (roomId != 0 && roomId != -1) {
                 goToUpdateCozyRoomDetailInfoActivity()
@@ -51,7 +57,13 @@ class MyPageFragment : Fragment() {
             loadSchool()
         }
         binding.tvSignout.setOnClickListener {
-            performLogout()
+            val text = listOf("로그아웃 하시겠어요?", "취소", "확인")
+            val dialog = OneButtonPopup(text, object : PopupClick {
+                override fun clickFunction() {
+                    performLogout()
+                }
+            }, false)
+            dialog.show(parentFragmentManager, "LogoutPopup")
         }
         binding.tvWithdraw.setOnClickListener {
             val intent: Intent = Intent(activity, WithDrawActivity::class.java)
@@ -138,8 +150,8 @@ class MyPageFragment : Fragment() {
 
     // 방정보 수정페이지로 전환
     private fun goToUpdateCozyRoomDetailInfoActivity() {
-        val intent = Intent(requireContext(), UpdateCozyRoomDetailInfoActivity::class.java)
-        intent.putExtra(UpdateCozyRoomDetailInfoActivity.ARG_ROOM_ID, roomId)
+        val intent = Intent(requireContext(), UpdateMyRoomInfoActivity::class.java)
+        intent.putExtra(UpdateMyRoomInfoActivity.ARG_ROOM_ID, roomId)
         startActivity(intent)
     }
 

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateBirthFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateBirthFragment.kt
@@ -1,0 +1,39 @@
+package umc.cozymate.ui.my_page
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import umc.cozymate.databinding.FragmentUpdateBirthBinding
+
+class UpdateBirthFragment: Fragment() {
+    private val TAG = this.javaClass.simpleName
+    private var _binding: FragmentUpdateBirthBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentUpdateBirthBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        with(binding) {
+            // 뒤로가기
+            ivBack.setOnClickListener {
+                requireActivity().finish()
+            }
+
+            // 생년월일 수정
+            btnNext.setOnClickListener {
+
+            }
+        }
+    }
+}

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateBirthFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateBirthFragment.kt
@@ -5,8 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import dagger.hilt.android.AndroidEntryPoint
 import umc.cozymate.databinding.FragmentUpdateBirthBinding
 
+@AndroidEntryPoint
 class UpdateBirthFragment: Fragment() {
     private val TAG = this.javaClass.simpleName
     private var _binding: FragmentUpdateBirthBinding? = null
@@ -27,7 +29,7 @@ class UpdateBirthFragment: Fragment() {
         with(binding) {
             // 뒤로가기
             ivBack.setOnClickListener {
-                requireActivity().finish()
+                requireActivity().onBackPressed()
             }
 
             // 생년월일 수정

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateCharacterFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateCharacterFragment.kt
@@ -5,8 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import dagger.hilt.android.AndroidEntryPoint
 import umc.cozymate.databinding.FragmentUpdateCharacterBinding
 
+@AndroidEntryPoint
 class UpdateCharacterFragment: Fragment() {
     private val TAG = this.javaClass.simpleName
     private var _binding: FragmentUpdateCharacterBinding? = null
@@ -27,7 +29,7 @@ class UpdateCharacterFragment: Fragment() {
         with(binding) {
             // 뒤로가기
             ivBack.setOnClickListener {
-                requireActivity().finish()
+                requireActivity().onBackPressed()
             }
             // 캐릭터 수정
             btnNext.setOnClickListener {

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateCharacterFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateCharacterFragment.kt
@@ -1,0 +1,36 @@
+package umc.cozymate.ui.my_page
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import umc.cozymate.databinding.FragmentUpdateCharacterBinding
+
+class UpdateCharacterFragment: Fragment() {
+    private val TAG = this.javaClass.simpleName
+    private var _binding: FragmentUpdateCharacterBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentUpdateCharacterBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        with(binding) {
+            // 뒤로가기
+            /*ivBack.setOnClickListener {
+                requireActivity().finish()
+            }*/
+            // 캐릭터 수정
+
+        }
+    }
+}

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateCharacterFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateCharacterFragment.kt
@@ -26,10 +26,13 @@ class UpdateCharacterFragment: Fragment() {
 
         with(binding) {
             // 뒤로가기
-            /*ivBack.setOnClickListener {
+            ivBack.setOnClickListener {
                 requireActivity().finish()
-            }*/
+            }
             // 캐릭터 수정
+            btnNext.setOnClickListener {
+
+            }
 
         }
     }

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateMajorFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateMajorFragment.kt
@@ -5,8 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import dagger.hilt.android.AndroidEntryPoint
 import umc.cozymate.databinding.FragmentUpdateMajorBinding
 
+@AndroidEntryPoint
 class UpdateMajorFragment: Fragment() {
     private val TAG = this.javaClass.simpleName
     private var _binding: FragmentUpdateMajorBinding? = null
@@ -27,7 +29,7 @@ class UpdateMajorFragment: Fragment() {
         with(binding) {
             // 뒤로가기
             ivBack.setOnClickListener {
-                requireActivity().finish()
+                requireActivity().onBackPressed()
             }
 
             // 학과 수정

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateMajorFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateMajorFragment.kt
@@ -1,0 +1,39 @@
+package umc.cozymate.ui.my_page
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import umc.cozymate.databinding.FragmentUpdateMajorBinding
+
+class UpdateMajorFragment: Fragment() {
+    private val TAG = this.javaClass.simpleName
+    private var _binding: FragmentUpdateMajorBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentUpdateMajorBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        with(binding) {
+            // 뒤로가기
+            ivBack.setOnClickListener {
+                requireActivity().finish()
+            }
+
+            // 학과 수정
+            btnNext.setOnClickListener {
+
+            }
+        }
+    }
+}

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyInfoActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyInfoActivity.kt
@@ -7,7 +7,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import umc.cozymate.R
 
-class UpdateUserInfoActivity : AppCompatActivity() {
+class UpdateMyInfoActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyInfoActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyInfoActivity.kt
@@ -1,21 +1,73 @@
 package umc.cozymate.ui.my_page
 
+import android.graphics.Color
 import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import umc.cozymate.R
+import umc.cozymate.databinding.ActivityUpdateMyInfoBinding
+import umc.cozymate.util.StatusBarUtil
 
 class UpdateMyInfoActivity : AppCompatActivity() {
+    lateinit var binding: ActivityUpdateMyInfoBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContentView(R.layout.activity_update_user_info)
+        binding = ActivityUpdateMyInfoBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        StatusBarUtil.updateStatusBarColor(this, Color.WHITE)
+        setContentView(R.layout.activity_update_my_info)
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
+        // 기본으로 [내 정보 수정 페이지] 로드
+        if (savedInstanceState == null) {
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.fragment_update_my_info, UpdateMyInfoFragment())
+                .commit()
+        }
+    }
+    // [캐릭터 수정 페이지] 로드
+    fun loadUpdateCharacterFragment() {
+        val fragment = UpdateCharacterFragment()
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragment_update_my_info, fragment)
+            .addToBackStack(null)
+            .commit()
+    }
+    // [닉네임 수정 페이지] 로드
+    fun loadUpdateNicknameFragment() {
+        val fragment = UpdateNicknameFragment()
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragment_update_my_info, fragment)
+            .addToBackStack(null)
+            .commit()
+    }
+    // [학과 수정 페이지] 로드
+    fun loadUpdateMajorFragment() {
+        val fragment = UpdateMajorFragment()
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragment_update_my_info, fragment)
+            .addToBackStack(null)
+            .commit()
+    }
+    // [생년월일 수정 페이지] 로드
+    fun loadUpdateBirthFragment() {
+        val fragment = UpdateBirthFragment()
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragment_update_my_info, fragment)
+            .addToBackStack(null)
+            .commit()
+    }
+    // [선호 칩 수정 페이지] 로드
+    fun loadUpdatePreferenceFragment() {
+        val fragment = UpdatePreferenceFragment()
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragment_update_my_info, fragment)
+            .addToBackStack(null)
+            .commit()
     }
 }

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyInfoActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyInfoActivity.kt
@@ -5,10 +5,12 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import dagger.hilt.android.AndroidEntryPoint
 import umc.cozymate.R
 import umc.cozymate.databinding.ActivityUpdateMyInfoBinding
 import umc.cozymate.util.StatusBarUtil
 
+@AndroidEntryPoint
 class UpdateMyInfoActivity : AppCompatActivity() {
     lateinit var binding: ActivityUpdateMyInfoBinding
 

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyInfoFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyInfoFragment.kt
@@ -5,12 +5,22 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import androidx.lifecycle.lifecycleScope
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import umc.cozymate.data.domain.Preference
 import umc.cozymate.databinding.FragmentUpdateMyInfoBinding
+import umc.cozymate.ui.viewmodel.UpdateInfoViewModel
+import umc.cozymate.util.CharacterUtil
 
+@AndroidEntryPoint
 class UpdateMyInfoFragment : Fragment() {
     private val TAG = this.javaClass.simpleName
     private var _binding: FragmentUpdateMyInfoBinding? = null
     private val binding get() = _binding!!
+    private val viewModel: UpdateInfoViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -18,11 +28,18 @@ class UpdateMyInfoFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentUpdateMyInfoBinding.inflate(inflater, container, false)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.fetchMemberInfo()
+            viewModel.fetchMyPreference()
+        }
         return binding.root
     }
 
     override fun onResume() {
         super.onResume()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.fetchMemberInfo()
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -57,6 +74,45 @@ class UpdateMyInfoFragment : Fragment() {
             llPreference.setOnClickListener {
                 (requireActivity() as UpdateMyInfoActivity).loadUpdatePreferenceFragment()
             }
+
+            observeResponse()
+        }
+    }
+
+    fun observeResponse() {
+        with(binding) {
+            viewModel.memberInfoResponse.observe(viewLifecycleOwner, Observer { response ->
+                if (response.result != null) {
+                    tvNickname.text = response.result.nickname
+                    tvBirth.text = response.result.birthday
+                    tvMajor.text = response.result.majorName
+                    CharacterUtil.setImg(response.result.persona, ivCharacter)
+                }
+            })
+            viewModel.myPreference.observe(viewLifecycleOwner, Observer { prefList ->
+                if (prefList != null) {
+                    val pref1 = Preference.entries.find { it.pref == prefList[0] }
+                    val pref2 = Preference.entries.find { it.pref == prefList[1] }
+                    val pref3 = Preference.entries.find { it.pref == prefList[2] }
+                    val pref4 = Preference.entries.find { it.pref == prefList[3] }
+                    if (pref1 != null) {
+                        tvCriteria1.text = pref1.displayName
+                        ivCriteriaIcon1.setImageResource(pref1.blueDrawable)
+                    }
+                    if (pref2 != null) {
+                        tvCriteria2.text = pref2.displayName
+                        ivCriteriaIcon2.setImageResource(pref2.blueDrawable)
+                    }
+                    if (pref3 != null) {
+                        tvCriteria3.text = pref3.displayName
+                        ivCriteriaIcon3.setImageResource(pref3.blueDrawable)
+                    }
+                    if (pref4 != null) {
+                        tvCriteria4.text = pref4.displayName
+                        ivCriteriaIcon4.setImageResource(pref4.blueDrawable)
+                    }
+                }
+            })
         }
     }
 }

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyInfoFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyInfoFragment.kt
@@ -21,6 +21,10 @@ class UpdateMyInfoFragment : Fragment() {
         return binding.root
     }
 
+    override fun onResume() {
+        super.onResume()
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -30,14 +34,29 @@ class UpdateMyInfoFragment : Fragment() {
                 requireActivity().finish()
             }
             // 캐릭터 수정
+            ivUpdateCharacter.setOnClickListener {
+                (requireActivity() as UpdateMyInfoActivity).loadUpdateCharacterFragment()
+            }
 
             // 닉네임 수정
+            llNickname.setOnClickListener {
+                (requireActivity() as UpdateMyInfoActivity).loadUpdateNicknameFragment()
+            }
 
             // 학과 수정
+            llMajor.setOnClickListener {
+                (requireActivity() as UpdateMyInfoActivity).loadUpdateMajorFragment()
+            }
 
             // 생년월일 수정
+            llBirth.setOnClickListener {
+                (requireActivity() as UpdateMyInfoActivity).loadUpdateBirthFragment()
+            }
 
             // 선호 칩 수정
+            llPreference.setOnClickListener {
+                (requireActivity() as UpdateMyInfoActivity).loadUpdatePreferenceFragment()
+            }
         }
     }
 }

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyInfoFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyInfoFragment.kt
@@ -1,0 +1,43 @@
+package umc.cozymate.ui.my_page
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import umc.cozymate.databinding.FragmentUpdateMyInfoBinding
+
+class UpdateMyInfoFragment : Fragment() {
+    private val TAG = this.javaClass.simpleName
+    private var _binding: FragmentUpdateMyInfoBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentUpdateMyInfoBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        with(binding) {
+            // 뒤로가기
+            ivBack.setOnClickListener {
+                requireActivity().finish()
+            }
+            // 캐릭터 수정
+
+            // 닉네임 수정
+
+            // 학과 수정
+
+            // 생년월일 수정
+
+            // 선호 칩 수정
+        }
+    }
+}

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyRoomInfoActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateMyRoomInfoActivity.kt
@@ -18,7 +18,7 @@ import umc.cozymate.ui.viewmodel.MakingRoomViewModel
 
 // TODO: 방 수정, 방 나가기, 방 전환(공개방/비공개방)
 @AndroidEntryPoint
-class UpdateCozyRoomDetailInfoActivity : AppCompatActivity() {
+class UpdateMyRoomInfoActivity : AppCompatActivity() {
     private val TAG = this.javaClass.simpleName
     private lateinit var binding: ActivityUpdateCozyRoomDetailInfoBinding
     private val viewModel: MakingRoomViewModel by viewModels()
@@ -70,7 +70,7 @@ class UpdateCozyRoomDetailInfoActivity : AppCompatActivity() {
     }
     // 코지홈으로 화면 전환
     fun loadMainActivity() {
-        val intent = Intent(this@UpdateCozyRoomDetailInfoActivity, MainActivity::class.java)
+        val intent = Intent(this@UpdateMyRoomInfoActivity, MainActivity::class.java)
         // 방 나가기 후에 상태변수를 설정해줍니다.
         intent.putExtra("isRoomExist", false)
         intent.putExtra("isRoomManager", false)

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdateNicknameFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdateNicknameFragment.kt
@@ -1,0 +1,39 @@
+package umc.cozymate.ui.my_page
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import umc.cozymate.databinding.FragmentUpdateNicknameBinding
+
+class UpdateNicknameFragment: Fragment() {
+    private val TAG = this.javaClass.simpleName
+    private var _binding: FragmentUpdateNicknameBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentUpdateNicknameBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        with(binding) {
+            // 뒤로가기
+            ivBack.setOnClickListener {
+                requireActivity().finish()
+            }
+
+            // 닉네임 수정
+            btnNext.setOnClickListener {
+
+            }
+        }
+    }
+}

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdatePreferenceFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdatePreferenceFragment.kt
@@ -5,8 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
 import umc.cozymate.databinding.FragmentUpdatePreferenceBinding
 
+@AndroidEntryPoint
 class UpdatePreferenceFragment: BottomSheetDialogFragment() {
     private val TAG = this.javaClass.simpleName
     private var _binding: FragmentUpdatePreferenceBinding? = null

--- a/app/src/main/java/umc/cozymate/ui/my_page/UpdatePreferenceFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/UpdatePreferenceFragment.kt
@@ -1,0 +1,34 @@
+package umc.cozymate.ui.my_page
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import umc.cozymate.databinding.FragmentUpdatePreferenceBinding
+
+class UpdatePreferenceFragment: BottomSheetDialogFragment() {
+    private val TAG = this.javaClass.simpleName
+    private var _binding: FragmentUpdatePreferenceBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentUpdatePreferenceBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        with(binding) {
+            // 선호 칩 수정
+            btnNext.setOnClickListener {
+
+            }
+        }
+    }
+}

--- a/app/src/main/java/umc/cozymate/ui/onboarding/OnboardingUserInfoFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/onboarding/OnboardingUserInfoFragment.kt
@@ -126,7 +126,7 @@ class OnboardingUserInfoFragment : Fragment() {
                     containsSeparatedHangul -> {
                         binding.tvLabelNickname.setTextColor(resources.getColor(R.color.red))
                         binding.tvAlertNickname.visibility = View.VISIBLE
-                        binding.tvAlertNickname.text = "닉네임은 분리된 한글(초성, 중성)이 포함되면 안됩니다!"
+                        binding.tvAlertNickname.text = "닉네임은 분리된 한글(모음, 자음)이 포함되면 안됩니다!"
                         binding.tilOnboardingNickname.isErrorEnabled = true
                         binding.tilOnboardingNickname.boxStrokeColor = resources.getColor(R.color.red)
                     }

--- a/app/src/main/java/umc/cozymate/ui/viewmodel/UpdateInfoViewModel.kt
+++ b/app/src/main/java/umc/cozymate/ui/viewmodel/UpdateInfoViewModel.kt
@@ -1,0 +1,68 @@
+package umc.cozymate.ui.viewmodel
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import umc.cozymate.data.model.response.member.MemberInfoResponse
+import umc.cozymate.data.repository.repository.MemberRepository
+import umc.cozymate.data.repository.repository.MemberStatPreferenceRepository
+import javax.inject.Inject
+
+@HiltViewModel
+class UpdateInfoViewModel @Inject constructor(
+    private val repo: MemberRepository,
+    private val prefRepo: MemberStatPreferenceRepository,
+    @ApplicationContext private val context: Context
+) : ViewModel() {
+    private val TAG = this.javaClass.simpleName
+    private val sharedPreferences = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
+    fun getToken(): String? {
+        return sharedPreferences.getString("access_token", null)
+    }
+
+    // 정보 불러오기
+    private val _loading = MutableLiveData<Boolean>()
+    val loading: LiveData<Boolean> get() = _loading
+    private val _memberInfoResponse = MutableLiveData<MemberInfoResponse>()
+    val memberInfoResponse: LiveData<MemberInfoResponse> get() = _memberInfoResponse
+    suspend fun fetchMemberInfo() {
+        val token = getToken()
+        if (token != null) {
+            val response = repo.getMemberInfo(token)
+            if (response.isSuccessful) {
+                if (response.body()!!.isSuccess) {
+                    _memberInfoResponse.value = response.body()
+                }
+            }
+        }
+    }
+
+    // 선호항목 조회
+    private val _myPreference = MutableLiveData<List<String>>()
+    val myPreference: LiveData<List<String>> get() = _myPreference
+    suspend fun fetchMyPreference() {
+        _loading.value = true
+        val token = getToken()
+        try {
+            val response = prefRepo.getMyPreference(token!!)
+            if (response.isSuccessful) {
+                if (response.body()?.isSuccess == true) {
+                    Log.d(TAG, "선호 항목 조회 성공: ${response.body()!!.result} ")
+                    _myPreference.value = response.body()!!.result?.preferenceList
+                } else Log.d(TAG, "선호 항목 조회 에러 메시지: ${response}")
+            } else {
+                _loading.value = false
+                Log.d(TAG, "선호 항복 조회 api 응답 실패: ${response.errorBody()?.string()}")
+            }
+        } catch (e: Exception) {
+            Log.d(TAG, "선호 항목 조회 api 요청 실패: $e ")
+        } finally {
+            _loading.value = false
+        }
+
+    }
+}

--- a/app/src/main/res/drawable/ic_update_char.xml
+++ b/app/src/main/res/drawable/ic_update_char.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="106dp"
+    android:height="32dp"
+    android:viewportWidth="106"
+    android:viewportHeight="32">
+  <path
+      android:pathData="M0,0C10.31,19.08 30.18,32 53,32C75.82,32 95.68,19.08 106,0H0Z"
+      android:fillColor="#3E3E3E"
+      android:fillAlpha="0.4"/>
+</vector>

--- a/app/src/main/res/layout/activity_update_my_info.xml
+++ b/app/src/main/res/layout/activity_update_my_info.xml
@@ -7,14 +7,11 @@
     android:layout_height="match_parent"
     tools:context=".ui.my_page.UpdateMyInfoActivity">
 
-    <ImageView
-        android:id="@+id/iv_back"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
-        android:layout_marginTop="8dp"
-        android:src="@drawable/ic_back"
+    <FrameLayout
+        android:id="@+id/fragment_update_my_info"
+        android:name="umc.cozymate.ui.onboarding.OnboardingUserInfoFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
+        app:layout_constraintTop_toTopOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_update_user_info.xml
+++ b/app/src/main/res/layout/activity_update_user_info.xml
@@ -5,7 +5,7 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.my_page.UpdateUserInfoActivity">
+    tools:context=".ui.my_page.UpdateMyInfoActivity">
 
     <ImageView
         android:id="@+id/iv_back"

--- a/app/src/main/res/layout/fragment_my_sent_request_component.xml
+++ b/app/src/main/res/layout/fragment_my_sent_request_component.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    tools:context=".ui.cozy_home.room.my_room.MyRoomComponent">
+    android:id="@+id/cl_component">
 
     <TextView
         android:id="@+id/tv_my_nickname"

--- a/app/src/main/res/layout/fragment_mypage.xml
+++ b/app/src/main/res/layout/fragment_mypage.xml
@@ -271,6 +271,7 @@
         android:orientation="horizontal"
         android:layout_marginTop="16dp"
         app:layout_constraintTop_toBottomOf="@id/layout_inquiry"
+        app:layout_constraintBottom_toTopOf="@id/cl_bottom"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
         <TextView
@@ -299,4 +300,13 @@
             android:textColor="@color/unuse_font"
             android:gravity="center_vertical"/>
     </LinearLayout>
+
+    <!-- 바텀뷰만큼 띄우기위한 코드-->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_bottom"
+        android:layout_width="match_parent"
+        android:layout_height="80dp"
+        app:layout_constraintTop_toBottomOf="@id/layout_inquiry"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_onboarding_user_info.xml
+++ b/app/src/main/res/layout/fragment_onboarding_user_info.xml
@@ -294,8 +294,7 @@
                 android:textColor="@color/unuse_font"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                />
+                app:layout_constraintStart_toStartOf="parent" />
 
             <Spinner
                 android:id="@+id/spinner_university"
@@ -303,19 +302,27 @@
                 android:layout_height="match_parent"
                 android:layout_marginTop="10dp"
                 android:layout_marginEnd="20dp"
-                android:overlapAnchor="false"
                 android:background="@drawable/spinner_bg"
+                android:dropDownWidth="match_parent"
+                android:overlapAnchor="false"
                 android:popupBackground="@drawable/spinner_background"
                 android:spinnerMode="dropdown"
-                android:dropDownWidth="match_parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/tv_label_university"
-                />
+                app:layout_constraintTop_toTopOf="@id/tv_label_university" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </com.google.android.material.card.MaterialCardView>
+
+    <!-- 띄우기위한 코드-->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_bottom"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        app:layout_constraintTop_toBottomOf="@id/mcv_university"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <!--다음 버튼-->
     <androidx.appcompat.widget.AppCompatButton

--- a/app/src/main/res/layout/fragment_university_certification_info.xml
+++ b/app/src/main/res/layout/fragment_university_certification_info.xml
@@ -14,16 +14,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/tv_roommate3"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="이 필요해요!"
-        android:textAppearance="@style/TextAppearance.App.20sp.SemiBold"
-        android:textColor="@color/highlight_font"
-        app:layout_constraintBaseline_toBaselineOf="@+id/tv_roommate2"
-        app:layout_constraintStart_toEndOf="@+id/tv_roommate2" />
-
     <!-- 학교-->
     <ImageView
         android:id="@+id/btn_university"
@@ -33,7 +23,7 @@
         android:layout_marginTop="74dp"
         android:src="@drawable/custom_rectangle_12"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@id/tv_roommate1" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/tv_university_guide"
@@ -53,79 +43,11 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="20dp"
         android:layout_marginTop="24dp"
-        android:text="학교를 선택해주세요"
+        android:text="인하대학교"
         android:textAppearance="@style/TextAppearance.App.14sp.Medium"
         android:textColor="@color/unuse_font"
         app:layout_constraintStart_toStartOf="@id/btn_university"
         app:layout_constraintTop_toTopOf="@id/tv_university_guide" />
-
-    <Spinner
-        android:id="@+id/spinner_university"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:layout_marginEnd="20dp"
-        android:background="@drawable/spinner_bg"
-        android:dropDownWidth="match_parent"
-        android:overlapAnchor="false"
-        android:popupBackground="@drawable/spinner_background"
-        android:spinnerMode="dropdown"
-        app:layout_constraintEnd_toEndOf="@id/btn_university"
-        app:layout_constraintStart_toStartOf="@id/btn_university"
-        app:layout_constraintTop_toTopOf="@id/tv_university_guide" />
-
-    <!-- 학과-->
-    <ImageView
-        android:id="@+id/btn_major"
-        android:layout_width="match_parent"
-        android:layout_height="80dp"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginTop="20dp"
-        android:src="@drawable/custom_rectangle_12"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/btn_university" />
-
-    <TextView
-        android:id="@+id/tv_major_guide"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:layout_marginTop="20dp"
-        android:text="학과"
-        android:textAppearance="@style/TextAppearance.App.12sp.SemiBold"
-        android:textColor="@color/color_font"
-        app:layout_constraintStart_toStartOf="@id/btn_major"
-        app:layout_constraintTop_toTopOf="@+id/btn_major" />
-
-    <TextView
-        android:id="@+id/tv_major"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:layout_marginTop="24dp"
-        android:background="@null"
-        android:hint="학과를 입력해주세요"
-        android:padding="0dp"
-        android:textAppearance="@style/TextAppearance.App.14sp.Medium"
-        android:textColor="@color/basic_font"
-        android:textColorHint="@color/unuse_font"
-        app:layout_constraintStart_toStartOf="@id/btn_major"
-        app:layout_constraintTop_toTopOf="@id/tv_major_guide" />
-
-    <Spinner
-        android:id="@+id/spinner_major"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:layout_marginEnd="20dp"
-        android:background="@drawable/spinner_bg"
-        android:dropDownWidth="match_parent"
-        android:overlapAnchor="false"
-        android:popupBackground="@drawable/spinner_background"
-        android:spinnerMode="dropdown"
-        app:layout_constraintEnd_toEndOf="@id/btn_university"
-        app:layout_constraintStart_toStartOf="@id/btn_university"
-        app:layout_constraintTop_toTopOf="@id/tv_major_guide" />
 
     <!-- 학교 이메일-->
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -136,7 +58,7 @@
         android:layout_marginTop="20dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/btn_major">
+        app:layout_constraintTop_toBottomOf="@id/btn_university">
 
         <ImageView
             android:id="@+id/btn_university_email"
@@ -174,114 +96,6 @@
             app:layout_constraintTop_toTopOf="@id/tv_university_email" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/btn_send_verify_code"
-        android:layout_width="96dp"
-        android:layout_height="33dp"
-        android:layout_marginEnd="20dp"
-        android:background="@drawable/btn_rectangle_26"
-        android:elevation="0dp"
-        android:outlineProvider="none"
-        android:text="인증번호 전송"
-        android:textAppearance="@style/TextAppearance.App.12sp.Medium"
-        android:textColor="@color/main_blue"
-        android:visibility="visible"
-        app:layout_constraintBottom_toBottomOf="@id/cl_email_input"
-        app:layout_constraintEnd_toEndOf="@id/cl_email_input"
-        app:layout_constraintTop_toTopOf="@id/cl_email_input" />
-
-    <TextView
-        android:id="@+id/tv_alert_email"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="4dp"
-        android:text="이메일을 다시 확인해주세요!"
-        android:textAppearance="@style/TextAppearance.App.12sp.Medium"
-        android:textColor="@color/red"
-        android:textSize="10dp"
-        android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/cl_email_input"
-        app:layout_constraintTop_toBottomOf="@id/cl_email_input" />
-
-    <!--인증번호 확인-->
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/cl_check_verify_code"
-        android:layout_width="0dp"
-        android:layout_height="80dp"
-        android:layout_marginHorizontal="20dp"
-        android:layout_marginTop="20dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/cl_email_input">
-
-        <ImageView
-            android:id="@+id/iv_check_verify_code"
-            android:layout_width="match_parent"
-            android:layout_height="80dp"
-            android:src="@drawable/custom_rectangle_12"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/tv_check_verify_code"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="20dp"
-            android:text="인증번호 확인"
-            android:textAppearance="@style/TextAppearance.App.12sp.SemiBold"
-            android:textColor="@color/color_font"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <EditText
-            android:id="@+id/et_check_verify_code"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="24dp"
-            android:background="@null"
-            android:hint="인증번호를 입력해주세요"
-            android:padding="0dp"
-            android:textAppearance="@style/TextAppearance.App.14sp.Medium"
-            android:textColor="@color/basic_font"
-            android:textColorHint="@color/unuse_font"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/tv_check_verify_code" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/btn_check_verify_code"
-        android:layout_width="96dp"
-        android:layout_height="33dp"
-        android:layout_marginEnd="20dp"
-        android:background="@drawable/btn_rectangle_26"
-        android:elevation="0dp"
-        android:outlineProvider="none"
-        android:text="인증번호 확인"
-        android:textAppearance="@style/TextAppearance.App.12sp.Medium"
-        android:textColor="@color/main_blue"
-        android:visibility="visible"
-        app:layout_constraintBottom_toBottomOf="@id/cl_check_verify_code"
-        app:layout_constraintEnd_toEndOf="@id/cl_check_verify_code"
-        app:layout_constraintTop_toTopOf="@id/cl_check_verify_code" />
-
-    <TextView
-        android:id="@+id/tv_alert_code"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="4dp"
-        android:text="인증번호를 다시 확인해주세요!"
-        android:textAppearance="@style/TextAppearance.App.12sp.Medium"
-        android:textColor="@color/red"
-        android:textSize="10dp"
-        android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/cl_check_verify_code"
-        app:layout_constraintTop_toBottomOf="@id/cl_check_verify_code" />
 
     <!-- 바텀뷰만큼 -->
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/fragment_update_birth.xml
+++ b/app/src/main/res/layout/fragment_update_birth.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/iv_back"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="8dp"
+        android:src="@drawable/ic_back"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!--닉네임-->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_onboarding_nickname"
+        android:layout_width="0dp"
+        android:layout_height="80dp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="24dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/iv_back">
+
+        <TextView
+            android:id="@+id/tv_label_nickname"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="20dp"
+            android:text="닉네임"
+            android:textAppearance="@style/TextAppearance.App.12sp.SemiBold"
+            android:textColor="@color/color_font"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_onboarding_nickname"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:boxCornerRadiusBottomEnd="12dp"
+            app:boxCornerRadiusBottomStart="12dp"
+            app:boxCornerRadiusTopEnd="12dp"
+            app:boxCornerRadiusTopStart="12dp"
+            app:boxStrokeErrorColor="@color/red"
+            app:boxStrokeWidth="1dp"
+            app:boxStrokeWidthFocused="1dp"
+            app:counterMaxLength="9"
+            app:errorTextColor="@color/red"
+            app:hintEnabled="false"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_onboarding_nickname"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:hint="닉네임을 입력해주세요"
+                android:inputType="text"
+                android:paddingStart="20dp"
+                android:paddingTop="43dp"
+                android:paddingEnd="20dp"
+                android:textAppearance="@style/TextAppearance.App.14sp.SemiBold"
+                android:textColor="@color/color_font"
+                android:textColorHint="@color/unuse_font"
+                android:textCursorDrawable="@color/black" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <TextView
+        android:id="@+id/tv_alert_nickname"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="4dp"
+        android:text="닉네임은 2~8자인 한글, 영어, 숫자만 가능해요!"
+        android:textAppearance="@style/TextAppearance.App.12sp.Medium"
+        android:textColor="@color/red"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="@id/cl_onboarding_nickname"
+        app:layout_constraintTop_toBottomOf="@id/cl_onboarding_nickname" />
+
+    <!--수정 버튼-->
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_next"
+        android:layout_width="0dp"
+        android:layout_height="54dp"
+        android:layout_marginHorizontal="22dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/btn_rectangle_next_state"
+        android:text="수정"
+        android:textAppearance="@style/TextAppearance.App.16sp.SemiBold"
+        android:textColor="@color/white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_update_birth.xml
+++ b/app/src/main/res/layout/fragment_update_birth.xml
@@ -14,74 +14,62 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <!--닉네임-->
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/cl_onboarding_nickname"
+    <!--생년월일-->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_birth"
         android:layout_width="0dp"
         android:layout_height="80dp"
         android:layout_marginHorizontal="20dp"
-        android:layout_marginTop="24dp"
+        android:layout_marginTop="28dp"
+        android:backgroundTint="@color/white"
+        app:cardCornerRadius="12dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/iv_back">
+        app:layout_constraintTop_toBottomOf="@id/iv_back"
+        app:rippleColor="@color/transparent"
+        app:strokeColor="@color/unuse">
 
-        <TextView
-            android:id="@+id/tv_label_nickname"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="20dp"
-            android:text="닉네임"
-            android:textAppearance="@style/TextAppearance.App.12sp.SemiBold"
-            android:textColor="@color/color_font"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/til_onboarding_nickname"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:boxCornerRadiusBottomEnd="12dp"
-            app:boxCornerRadiusBottomStart="12dp"
-            app:boxCornerRadiusTopEnd="12dp"
-            app:boxCornerRadiusTopStart="12dp"
-            app:boxStrokeErrorColor="@color/red"
-            app:boxStrokeWidth="1dp"
-            app:boxStrokeWidthFocused="1dp"
-            app:counterMaxLength="9"
-            app:errorTextColor="@color/red"
-            app:hintEnabled="false"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            android:layout_height="match_parent">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/et_onboarding_nickname"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:hint="닉네임을 입력해주세요"
-                android:inputType="text"
-                android:paddingStart="20dp"
-                android:paddingTop="43dp"
-                android:paddingEnd="20dp"
-                android:textAppearance="@style/TextAppearance.App.14sp.SemiBold"
+            <TextView
+                android:id="@+id/tv_label_birth"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="20dp"
+                android:text="생년월일"
+                android:textAppearance="@style/TextAppearance.App.12sp.SemiBold"
                 android:textColor="@color/color_font"
-                android:textColorHint="@color/unuse_font"
-                android:textCursorDrawable="@color/black" />
-        </com.google.android.material.textfield.TextInputLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/tv_alert_nickname"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="4dp"
-        android:text="닉네임은 2~8자인 한글, 영어, 숫자만 가능해요!"
-        android:textAppearance="@style/TextAppearance.App.12sp.Medium"
-        android:textColor="@color/red"
-        android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/cl_onboarding_nickname"
-        app:layout_constraintTop_toBottomOf="@id/cl_onboarding_nickname" />
+            <TextView
+                android:id="@+id/tv_birth"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginBottom="21dp"
+                android:textAppearance="@style/TextAppearance.App.12sp.SemiBold"
+                android:textColor="@color/basic_font"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="20dp"
+                android:layout_marginBottom="11.5dp"
+                android:src="@drawable/ic_dropdown"
+                app:layout_constraintBottom_toBottomOf="@id/tv_birth"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_birth" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </com.google.android.material.card.MaterialCardView>
 
     <!--수정 버튼-->
     <androidx.appcompat.widget.AppCompatButton

--- a/app/src/main/res/layout/fragment_update_character.xml
+++ b/app/src/main/res/layout/fragment_update_character.xml
@@ -5,30 +5,15 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:id="@+id/tv_onboarding2_title1"
+    <ImageView
+        android:id="@+id/iv_back"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="28dp"
-        android:layout_marginTop="56dp"
-        android:text="cozymate와 함께할"
-        android:textAppearance="@style/TextAppearance.App.18sp.SemiBold"
-        android:textColor="@color/highlight_font"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="8dp"
+        android:src="@drawable/ic_back"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        />
-
-    <TextView
-        android:id="@+id/tv_onboarding2_title2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="28dp"
-        android:text="캐릭터를 선택해주세요!"
-        android:textAppearance="@style/TextAppearance.App.18sp.SemiBold"
-        android:textColor="@color/highlight_font"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_onboarding2_title1"
-        />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_list"
@@ -39,7 +24,7 @@
         app:layoutManager="GridLayoutManager"
         app:spanCount="4"
         tools:listitem="@layout/item_character"
-        app:layout_constraintTop_toTopOf="@id/tv_onboarding2_title1"
+        app:layout_constraintTop_toBottomOf="@id/iv_back"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
     </androidx.recyclerview.widget.RecyclerView>
@@ -52,7 +37,7 @@
         android:layout_marginBottom="8dp"
         android:background="@drawable/btn_rectangle_next_state"
         android:textAppearance="@style/TextAppearance.App.16sp.SemiBold"
-        android:text="다음"
+        android:text="수정"
         android:textColor="@color/white"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_update_character.xml
+++ b/app/src/main/res/layout/fragment_update_character.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <TextView
+        android:id="@+id/tv_onboarding2_title1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="28dp"
+        android:layout_marginTop="56dp"
+        android:text="cozymate와 함께할"
+        android:textAppearance="@style/TextAppearance.App.18sp.SemiBold"
+        android:textColor="@color/highlight_font"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        />
+
+    <TextView
+        android:id="@+id/tv_onboarding2_title2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="28dp"
+        android:text="캐릭터를 선택해주세요!"
+        android:textAppearance="@style/TextAppearance.App.18sp.SemiBold"
+        android:textColor="@color/highlight_font"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_onboarding2_title1"
+        />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="28dp"
+        android:layout_marginHorizontal="6.5dp"
+        app:layoutManager="GridLayoutManager"
+        app:spanCount="4"
+        tools:listitem="@layout/item_character"
+        app:layout_constraintTop_toTopOf="@id/tv_onboarding2_title1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+    </androidx.recyclerview.widget.RecyclerView>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_next"
+        android:layout_width="0dp"
+        android:layout_height="54dp"
+        android:layout_marginHorizontal="22dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/btn_rectangle_next_state"
+        android:textAppearance="@style/TextAppearance.App.16sp.SemiBold"
+        android:text="다음"
+        android:textColor="@color/white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_update_major.xml
+++ b/app/src/main/res/layout/fragment_update_major.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/iv_back"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="8dp"
+        android:src="@drawable/ic_back"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!--닉네임-->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_onboarding_nickname"
+        android:layout_width="0dp"
+        android:layout_height="80dp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="24dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/iv_back">
+
+        <TextView
+            android:id="@+id/tv_label_nickname"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="20dp"
+            android:text="닉네임"
+            android:textAppearance="@style/TextAppearance.App.12sp.SemiBold"
+            android:textColor="@color/color_font"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_onboarding_nickname"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:boxCornerRadiusBottomEnd="12dp"
+            app:boxCornerRadiusBottomStart="12dp"
+            app:boxCornerRadiusTopEnd="12dp"
+            app:boxCornerRadiusTopStart="12dp"
+            app:boxStrokeErrorColor="@color/red"
+            app:boxStrokeWidth="1dp"
+            app:boxStrokeWidthFocused="1dp"
+            app:counterMaxLength="9"
+            app:errorTextColor="@color/red"
+            app:hintEnabled="false"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_onboarding_nickname"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:hint="닉네임을 입력해주세요"
+                android:inputType="text"
+                android:paddingStart="20dp"
+                android:paddingTop="43dp"
+                android:paddingEnd="20dp"
+                android:textAppearance="@style/TextAppearance.App.14sp.SemiBold"
+                android:textColor="@color/color_font"
+                android:textColorHint="@color/unuse_font"
+                android:textCursorDrawable="@color/black" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <TextView
+        android:id="@+id/tv_alert_nickname"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="4dp"
+        android:text="닉네임은 2~8자인 한글, 영어, 숫자만 가능해요!"
+        android:textAppearance="@style/TextAppearance.App.12sp.Medium"
+        android:textColor="@color/red"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="@id/cl_onboarding_nickname"
+        app:layout_constraintTop_toBottomOf="@id/cl_onboarding_nickname" />
+
+    <!--수정 버튼-->
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_next"
+        android:layout_width="0dp"
+        android:layout_height="54dp"
+        android:layout_marginHorizontal="22dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/btn_rectangle_next_state"
+        android:text="수정"
+        android:textAppearance="@style/TextAppearance.App.16sp.SemiBold"
+        android:textColor="@color/white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_update_major.xml
+++ b/app/src/main/res/layout/fragment_update_major.xml
@@ -63,8 +63,8 @@
         android:overlapAnchor="false"
         android:popupBackground="@drawable/spinner_background"
         android:spinnerMode="dropdown"
-        app:layout_constraintEnd_toEndOf="@id/btn_university"
-        app:layout_constraintStart_toStartOf="@id/btn_university"
+        app:layout_constraintEnd_toEndOf="@id/btn_major"
+        app:layout_constraintStart_toStartOf="@id/btn_major"
         app:layout_constraintTop_toTopOf="@id/tv_major_guide" />
 
     <!--수정 버튼-->

--- a/app/src/main/res/layout/fragment_update_major.xml
+++ b/app/src/main/res/layout/fragment_update_major.xml
@@ -14,74 +14,58 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <!--닉네임-->
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/cl_onboarding_nickname"
-        android:layout_width="0dp"
+    <!-- 학과-->
+    <ImageView
+        android:id="@+id/btn_major"
+        android:layout_width="match_parent"
         android:layout_height="80dp"
         android:layout_marginHorizontal="20dp"
-        android:layout_marginTop="24dp"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="20dp"
+        android:src="@drawable/custom_rectangle_12"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/iv_back">
-
-        <TextView
-            android:id="@+id/tv_label_nickname"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="20dp"
-            android:text="닉네임"
-            android:textAppearance="@style/TextAppearance.App.12sp.SemiBold"
-            android:textColor="@color/color_font"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/til_onboarding_nickname"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:boxCornerRadiusBottomEnd="12dp"
-            app:boxCornerRadiusBottomStart="12dp"
-            app:boxCornerRadiusTopEnd="12dp"
-            app:boxCornerRadiusTopStart="12dp"
-            app:boxStrokeErrorColor="@color/red"
-            app:boxStrokeWidth="1dp"
-            app:boxStrokeWidthFocused="1dp"
-            app:counterMaxLength="9"
-            app:errorTextColor="@color/red"
-            app:hintEnabled="false"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/et_onboarding_nickname"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:hint="닉네임을 입력해주세요"
-                android:inputType="text"
-                android:paddingStart="20dp"
-                android:paddingTop="43dp"
-                android:paddingEnd="20dp"
-                android:textAppearance="@style/TextAppearance.App.14sp.SemiBold"
-                android:textColor="@color/color_font"
-                android:textColorHint="@color/unuse_font"
-                android:textCursorDrawable="@color/black" />
-        </com.google.android.material.textfield.TextInputLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        app:layout_constraintTop_toBottomOf="@id/btn_university" />
 
     <TextView
-        android:id="@+id/tv_alert_nickname"
+        android:id="@+id/tv_major_guide"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="4dp"
-        android:text="닉네임은 2~8자인 한글, 영어, 숫자만 가능해요!"
-        android:textAppearance="@style/TextAppearance.App.12sp.Medium"
-        android:textColor="@color/red"
-        android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@id/cl_onboarding_nickname"
-        app:layout_constraintTop_toBottomOf="@id/cl_onboarding_nickname" />
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="20dp"
+        android:text="학과"
+        android:textAppearance="@style/TextAppearance.App.12sp.SemiBold"
+        android:textColor="@color/color_font"
+        app:layout_constraintStart_toStartOf="@id/btn_major"
+        app:layout_constraintTop_toTopOf="@+id/btn_major" />
+
+    <TextView
+        android:id="@+id/tv_major"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="24dp"
+        android:background="@null"
+        android:hint="학과를 입력해주세요"
+        android:padding="0dp"
+        android:textAppearance="@style/TextAppearance.App.14sp.Medium"
+        android:textColor="@color/basic_font"
+        android:textColorHint="@color/unuse_font"
+        app:layout_constraintStart_toStartOf="@id/btn_major"
+        app:layout_constraintTop_toTopOf="@id/tv_major_guide" />
+
+    <Spinner
+        android:id="@+id/spinner_major"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="20dp"
+        android:background="@drawable/spinner_bg"
+        android:dropDownWidth="match_parent"
+        android:overlapAnchor="false"
+        android:popupBackground="@drawable/spinner_background"
+        android:spinnerMode="dropdown"
+        app:layout_constraintEnd_toEndOf="@id/btn_university"
+        app:layout_constraintStart_toStartOf="@id/btn_university"
+        app:layout_constraintTop_toTopOf="@id/tv_major_guide" />
 
     <!--수정 버튼-->
     <androidx.appcompat.widget.AppCompatButton

--- a/app/src/main/res/layout/fragment_update_my_info.xml
+++ b/app/src/main/res/layout/fragment_update_my_info.xml
@@ -349,7 +349,7 @@
         android:text="수정하기"
         android:textAppearance="@style/TextAppearance.App.12sp.Medium"
         android:textColor="@color/unuse_font"
-        app:layout_constraintBottom_toBottomOf="@id/layout_preference"
+        app:layout_constraintBottom_toBottomOf="@id/ll_preference"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 

--- a/app/src/main/res/layout/fragment_update_my_info.xml
+++ b/app/src/main/res/layout/fragment_update_my_info.xml
@@ -86,6 +86,7 @@
                 android:textColor="@color/unuse_font" />
 
             <TextView
+                android:id="@+id/tv_nickname"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_marginStart="8dp"

--- a/app/src/main/res/layout/fragment_update_nickname.xml
+++ b/app/src/main/res/layout/fragment_update_nickname.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/iv_back"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="8dp"
+        android:src="@drawable/ic_back"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!--닉네임-->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_onboarding_nickname"
+        android:layout_width="0dp"
+        android:layout_height="80dp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="24dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/iv_back">
+
+        <TextView
+            android:id="@+id/tv_label_nickname"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="20dp"
+            android:text="닉네임"
+            android:textAppearance="@style/TextAppearance.App.12sp.SemiBold"
+            android:textColor="@color/color_font"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_onboarding_nickname"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:boxCornerRadiusBottomEnd="12dp"
+            app:boxCornerRadiusBottomStart="12dp"
+            app:boxCornerRadiusTopEnd="12dp"
+            app:boxCornerRadiusTopStart="12dp"
+            app:boxStrokeErrorColor="@color/red"
+            app:boxStrokeWidth="1dp"
+            app:boxStrokeWidthFocused="1dp"
+            app:counterMaxLength="9"
+            app:errorTextColor="@color/red"
+            app:hintEnabled="false"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_onboarding_nickname"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:hint="닉네임을 입력해주세요"
+                android:inputType="text"
+                android:paddingStart="20dp"
+                android:paddingTop="43dp"
+                android:paddingEnd="20dp"
+                android:textAppearance="@style/TextAppearance.App.14sp.SemiBold"
+                android:textColor="@color/color_font"
+                android:textColorHint="@color/unuse_font"
+                android:textCursorDrawable="@color/black" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <TextView
+        android:id="@+id/tv_alert_nickname"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="4dp"
+        android:text="닉네임은 2~8자인 한글, 영어, 숫자만 가능해요!"
+        android:textAppearance="@style/TextAppearance.App.12sp.Medium"
+        android:textColor="@color/red"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="@id/cl_onboarding_nickname"
+        app:layout_constraintTop_toBottomOf="@id/cl_onboarding_nickname" />
+
+    <!--수정 버튼-->
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_next"
+        android:layout_width="0dp"
+        android:layout_height="54dp"
+        android:layout_marginHorizontal="22dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/btn_rectangle_next_state"
+        android:text="수정"
+        android:textAppearance="@style/TextAppearance.App.16sp.SemiBold"
+        android:textColor="@color/white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_update_preference.xml
+++ b/app/src/main/res/layout/fragment_update_preference.xml
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.flexbox.FlexboxLayout
+        android:id="@+id/flexbox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginTop="12dp"
+        app:flexWrap="wrap"
+        app:justifyContent="flex_start"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/chip_birth_year"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="출생년도" />
+
+        <TextView
+            android:id="@+id/chip_admission_year"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="학번" />
+
+        <TextView
+            android:id="@+id/chip_major"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="학과" />
+
+        <TextView
+            android:id="@+id/chip_acceptance"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="합격여부" />
+
+        <TextView
+            android:id="@+id/chip_wakeup_time"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="기상시간" />
+
+        <TextView
+            android:id="@+id/chip_sleeping_time"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="취침시간" />
+
+        <TextView
+            android:id="@+id/chip_turn_off_time"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="소등시간" />
+
+        <TextView
+            android:id="@+id/chip_smoking"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="흡연여부" />
+
+        <TextView
+            android:id="@+id/chip_sleeping_habit"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="잠버릇" />
+
+        <TextView
+            android:id="@+id/chip_air_conditioning_intensity"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="에어컨" />
+
+        <TextView
+            android:id="@+id/chip_heating_intensity"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="히터" />
+
+        <TextView
+            android:id="@+id/chip_life_pattern"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="생활패턴" />
+
+        <TextView
+            android:id="@+id/chip_intimacy"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="친밀도" />
+
+        <TextView
+            android:id="@+id/chip_can_share"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="물건공유" />
+
+        <TextView
+            android:id="@+id/chip_is_play_game"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="게임여부" />
+
+        <TextView
+            android:id="@+id/chip_is_phone_call"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="전화여부" />
+
+        <TextView
+            android:id="@+id/chip_studying"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="공부여부" />
+
+        <TextView
+            android:id="@+id/chip_intake"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="섭취여부" />
+
+        <TextView
+            android:id="@+id/chip_clean_sensitivity"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="청결예민도" />
+
+        <TextView
+            android:id="@+id/chip_noise_sensitivity"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="소음예민도" />
+
+        <TextView
+            android:id="@+id/chip_cleaning_frequency"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="청소빈도" />
+
+        <TextView
+            android:id="@+id/chip_drinking_frequency"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="음주빈도" />
+
+        <TextView
+            android:id="@+id/chip_personality"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="성격" />
+
+        <TextView
+            android:id="@+id/chip_mbti"
+            style="@style/RoommateElementChip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="MBTI" />
+    </com.google.android.flexbox.FlexboxLayout>
+
+    <!--수정 버튼-->
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_next"
+        android:layout_width="0dp"
+        android:layout_height="54dp"
+        android:layout_marginHorizontal="22dp"
+        android:layout_marginVertical="8dp"
+        android:background="@drawable/btn_rectangle_next_state"
+        android:text="수정"
+        android:textAppearance="@style/TextAppearance.App.16sp.SemiBold"
+        android:textColor="@color/white"
+        app:layout_constraintTop_toBottomOf="@id/flexbox"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_update_user)info.xml
+++ b/app/src/main/res/layout/fragment_update_user)info.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:indeterminateTint="@color/main_blue"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!-- 캐릭터 수정 -->
+    <ImageView
+        android:id="@+id/iv_character"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:layout_marginTop="99dp"
+        android:src="@drawable/ic_basic_character"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/ll_user_info"
+        android:layout_width="332dp"
+        android:layout_height="222dp"
+        android:layout_marginTop="53dp"
+        android:background="@drawable/background_stroke_12"
+        android:orientation="vertical"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="4dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/iv_character">
+
+        <LinearLayout
+            android:id="@+id/ll_nickname"
+            android:layout_width="match_parent"
+            android:layout_height="18dp"
+            android:layout_marginVertical="12dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:text="닉네임"
+                android:textAppearance="@style/TextAppearance.App.14sp.Medium"
+                android:textColor="@color/highlight_font" />
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <ImageView
+                android:id="@+id/btn_myinfo"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:src="@drawable/ic_next" />
+
+        </LinearLayout>
+
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:src="@drawable/line_mypage" />
+
+        <LinearLayout
+            android:id="@+id/ll_major"
+            android:layout_width="match_parent"
+            android:layout_height="18dp"
+            android:layout_marginVertical="12dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:text="학과"
+                android:textAppearance="@style/TextAppearance.App.14sp.Medium"
+                android:textColor="@color/highlight_font" />
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <TextView
+                android:id="@+id/tv_cozyroom"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_marginEnd="10.5dp"
+                android:text="학과명"
+                android:textAppearance="@style/TextAppearance.App.14sp.Medium"
+                android:textColor="@color/main_blue" />
+
+            <ImageView
+                android:id="@+id/btn_major"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:src="@drawable/ic_next" />
+
+        </LinearLayout>
+
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:src="@drawable/line_mypage" />
+
+        <LinearLayout
+            android:id="@+id/ll_birth"
+            android:layout_width="match_parent"
+            android:layout_height="18dp"
+            android:layout_marginVertical="12dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:text="생년월일"
+                android:textAppearance="@style/TextAppearance.App.14sp.Medium"
+                android:textColor="@color/highlight_font" />
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <TextView
+                android:id="@+id/tv_school"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_marginEnd="10.5dp"
+                android:text="yyyy년 mm월 dd일"
+                android:textAppearance="@style/TextAppearance.App.14sp.Medium"
+                android:textColor="@color/main_blue" />
+
+            <ImageView
+                android:id="@+id/btn_birth"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:src="@drawable/ic_next" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+
+    <LinearLayout
+        android:id="@+id/layout_inquiry"
+        android:layout_width="332dp"
+        android:layout_height="50dp"
+        android:layout_marginTop="16dp"
+        android:background="@drawable/background_stroke_12"
+        android:orientation="horizontal"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="4dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/ll_user_info">
+
+        <TextView
+            android:id="@+id/tv_signout"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:gravity="center_vertical"
+            android:text="수정하기"
+            android:textAppearance="@style/TextAppearance.App.12sp.Medium"
+            android:textColor="@color/unuse_font" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_update_user_info.xml
+++ b/app/src/main/res/layout/fragment_update_user_info.xml
@@ -16,6 +16,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <ImageView
+        android:id="@+id/iv_back"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="8dp"
+        android:src="@drawable/ic_back"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <!-- 캐릭터 수정 -->
     <ImageView
         android:id="@+id/iv_character"
@@ -30,7 +40,7 @@
     <LinearLayout
         android:id="@+id/ll_user_info"
         android:layout_width="332dp"
-        android:layout_height="222dp"
+        android:layout_height="wrap_content"
         android:layout_marginTop="53dp"
         android:background="@drawable/background_stroke_12"
         android:orientation="vertical"

--- a/app/src/main/res/layout/fragment_update_user_info.xml
+++ b/app/src/main/res/layout/fragment_update_user_info.xml
@@ -37,6 +37,27 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <ImageView
+        android:id="@+id/iv_update_character"
+        android:layout_width="120dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="99dp"
+        android:src="@drawable/ic_update_char"
+        app:layout_constraintBottom_toBottomOf="@id/iv_character"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="7dp"
+        android:text="수정"
+        android:textAppearance="@style/TextAppearance.App.12sp.SemiBold"
+        android:textColor="@color/white"
+        app:layout_constraintEnd_toEndOf="@id/iv_update_character"
+        app:layout_constraintStart_toStartOf="@id/iv_update_character"
+        app:layout_constraintTop_toTopOf="@id/iv_update_character" />
+
     <LinearLayout
         android:id="@+id/ll_user_info"
         android:layout_width="332dp"
@@ -61,6 +82,14 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:text="닉네임"
+                android:textAppearance="@style/TextAppearance.App.14sp.Medium"
+                android:textColor="@color/unuse_font" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_marginStart="8dp"
+                android:text=""
                 android:textAppearance="@style/TextAppearance.App.14sp.Medium"
                 android:textColor="@color/highlight_font" />
 
@@ -94,21 +123,21 @@
                 android:layout_height="match_parent"
                 android:text="학과"
                 android:textAppearance="@style/TextAppearance.App.14sp.Medium"
+                android:textColor="@color/unuse_font" />
+
+            <TextView
+                android:id="@+id/tv_cozyroom"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_marginStart="8dp"
+                android:text=""
+                android:textAppearance="@style/TextAppearance.App.14sp.Medium"
                 android:textColor="@color/highlight_font" />
 
             <View
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:layout_weight="1" />
-
-            <TextView
-                android:id="@+id/tv_cozyroom"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:layout_marginEnd="10.5dp"
-                android:text="학과명"
-                android:textAppearance="@style/TextAppearance.App.14sp.Medium"
-                android:textColor="@color/main_blue" />
 
             <ImageView
                 android:id="@+id/btn_major"
@@ -135,21 +164,21 @@
                 android:layout_height="match_parent"
                 android:text="생년월일"
                 android:textAppearance="@style/TextAppearance.App.14sp.Medium"
+                android:textColor="@color/unuse_font" />
+
+            <TextView
+                android:id="@+id/tv_school"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_marginStart="8dp"
+                android:text=""
+                android:textAppearance="@style/TextAppearance.App.14sp.Medium"
                 android:textColor="@color/highlight_font" />
 
             <View
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:layout_weight="1" />
-
-            <TextView
-                android:id="@+id/tv_school"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:layout_marginEnd="10.5dp"
-                android:text="yyyy년 mm월 dd일"
-                android:textAppearance="@style/TextAppearance.App.14sp.Medium"
-                android:textColor="@color/main_blue" />
 
             <ImageView
                 android:id="@+id/btn_birth"
@@ -163,26 +192,166 @@
 
 
     <LinearLayout
-        android:id="@+id/layout_inquiry"
+        android:id="@+id/layout_preference"
         android:layout_width="332dp"
-        android:layout_height="50dp"
+        android:layout_height="115dp"
         android:layout_marginTop="16dp"
         android:background="@drawable/background_stroke_12"
         android:orientation="horizontal"
         android:paddingHorizontal="16dp"
         android:paddingVertical="4dp"
+        android:gravity="center_horizontal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/ll_user_info">
 
-        <TextView
-            android:id="@+id/tv_signout"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:gravity="center_vertical"
-            android:text="수정하기"
-            android:textAppearance="@style/TextAppearance.App.12sp.Medium"
-            android:textColor="@color/unuse_font" />
+        <!-- 선호 기준1 -->
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_criteria_1"
+            android:layout_width="64dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="24dp"
+            app:layout_constraintEnd_toStartOf="@id/cl_criteria_2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/v_divider">
+
+            <ImageView
+                android:id="@+id/iv_criteria_icon_1"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:src="@drawable/ic_wake_up_time_blue"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_criteria_1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="기상시간"
+                android:textAppearance="@style/TextAppearance.App.12sp.Medium"
+                android:textColor="@color/highlight_font"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/iv_criteria_icon_1" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <!-- 선호 기준2 -->
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_criteria_2"
+            android:layout_width="64dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="24dp"
+            android:layout_marginStart="16dp"
+            app:layout_constraintEnd_toStartOf="@id/cl_criteria_2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/v_divider">
+
+            <ImageView
+                android:id="@+id/iv_criteria_icon_2"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:src="@drawable/ic_wake_up_time_blue"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_criteria_2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="기상시간"
+                android:textAppearance="@style/TextAppearance.App.12sp.Medium"
+                android:textColor="@color/highlight_font"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/iv_criteria_icon_2" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <!-- 선호 기준3 -->
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_criteria_3"
+            android:layout_width="64dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="24dp"
+            android:layout_marginStart="16dp"
+            app:layout_constraintEnd_toStartOf="@id/cl_criteria_2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/v_divider">
+
+            <ImageView
+                android:id="@+id/iv_criteria_icon_3"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:src="@drawable/ic_wake_up_time_blue"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_criteria_3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="기상시간"
+                android:textAppearance="@style/TextAppearance.App.12sp.Medium"
+                android:textColor="@color/highlight_font"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/iv_criteria_icon_3" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <!-- 선호 기준4 -->
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_criteria_4"
+            android:layout_width="64dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="24dp"
+            android:layout_marginStart="16dp"
+            app:layout_constraintEnd_toStartOf="@id/cl_criteria_2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/v_divider">
+
+            <ImageView
+                android:id="@+id/iv_criteria_icon_4"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:src="@drawable/ic_wake_up_time_blue"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_criteria_4"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="기상시간"
+                android:textAppearance="@style/TextAppearance.App.12sp.Medium"
+                android:textColor="@color/highlight_font"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/iv_criteria_icon_4" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </LinearLayout>
+
+    <TextView
+        android:id="@+id/tv_update_preference"
+        android:layout_width="203dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="20dp"
+        android:gravity="center_horizontal|center_vertical"
+        android:text="수정하기"
+        android:textAppearance="@style/TextAppearance.App.12sp.Medium"
+        android:textColor="@color/unuse_font"
+        app:layout_constraintBottom_toBottomOf="@id/layout_preference"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_update_user_info.xml
+++ b/app/src/main/res/layout/fragment_update_user_info.xml
@@ -126,7 +126,7 @@
                 android:textColor="@color/unuse_font" />
 
             <TextView
-                android:id="@+id/tv_cozyroom"
+                android:id="@+id/tv_major"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_marginStart="8dp"
@@ -167,7 +167,7 @@
                 android:textColor="@color/unuse_font" />
 
             <TextView
-                android:id="@+id/tv_school"
+                android:id="@+id/tv_birth"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_marginStart="8dp"
@@ -190,9 +190,8 @@
 
     </LinearLayout>
 
-
     <LinearLayout
-        android:id="@+id/layout_preference"
+        android:id="@+id/ll_preference"
         android:layout_width="332dp"
         android:layout_height="115dp"
         android:layout_marginTop="16dp"


### PR DESCRIPTION
## 📝작업 내용

> 마이페이지 정보수정 화면 내 정보 띄우기, 홈화면 컴포넌트 수정

### 스크린샷
홈화면
<img src="https://github.com/user-attachments/assets/4a6ffe0a-eea2-44b1-8445-1607d6cc05f4" width="250" />
- 참여요청 방 0개일 때 컴포넌트 안 띄우기
- 멤버 스탯없을 때 선호항목 "??"

마이페이지 내정보 화면
<img src="https://github.com/user-attachments/assets/5b6fca45-23de-4168-aa49-349181afb376" width="250" />
- 내 정보 api
- 아직 화면이동만 돼요

## 💬api 연결 todo
- [ ] 캐릭터 수정
- [ ] 닉네임 수정
- [ ] 학과 수정
- [ ] 생년월일 수정
- [ ] 선호 칩 수정
