### PR TITLE
학교 아이디 SharedPreference에 저장

### DIFF
--- a/app/src/main/java/umc/cozymate/ui/viewmodel/SplashViewModel.kt
+++ b/app/src/main/java/umc/cozymate/ui/viewmodel/SplashViewModel.kt
@@ -100,6 +100,7 @@ class SplashViewModel @Inject constructor(
         sharedPreferences.edit().putString("user_gender", _memberInfo.value!!.gender).commit()
         sharedPreferences.edit().putString("user_birthday", _memberInfo.value!!.birthday).commit()
         sharedPreferences.edit().putString("user_university_name", _memberInfo.value!!.universityName).commit()
+        sharedPreferences.edit().putInt("user_university_id", _memberInfo.value!!.universityId ?: 0).commit()
         sharedPreferences.edit().putString("user_major_name", _memberInfo.value!!.majorName).commit()
     }
 


### PR DESCRIPTION
## 📝작업 내용

> 학교 아이디를 "user_university_id"라는 이름으로 SharedPreference에 저장하도록 했습니다.
![image](https://github.com/user-attachments/assets/6c780002-67a1-4764-9e68-f5e5bdbec03a)

호출부 - 홈화면에서 멤버 정보 불러올때 (SplashViewModel.membercheck())

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자의 대학 ID를 저장하는 기능 추가
- **개선 사항**
	- 스플래시 화면에서 사용자 정보 저장 프로세스 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->