### PR TITLE
fix: 라이프스타일 입력 후 다음버튼 안보이는 문제 해결

### DIFF
--- a/app/src/main/java/umc/cozymate/ui/roommate/lifestyle_info/BasicInfoFragment.kt
+++ b/app/src/main/java/umc/cozymate/ui/roommate/lifestyle_info/BasicInfoFragment.kt
@@ -222,7 +222,7 @@ class BasicInfoFragment : Fragment() {
                 }
                 numPeopleOption = selectedTextView
                 saveToSharedPreferences(key, value as String)
-                resetDebounceTimer { showDormitoryLayout() }
+                resetDebounceTimer { showDormJoiningStatusLayout() }
                 updateNextButtonState()
             }
 
@@ -289,6 +289,11 @@ class BasicInfoFragment : Fragment() {
 
     private fun showDormitoryLayout() {
         binding.clDormName.showWithSlideDownAnimation()
+        scrollToTop()
+    }
+
+    private fun showDormJoiningStatusLayout() {
+        binding.clDormJoiningStatus.showWithSlideDownAnimation()
         scrollToTop()
     }
 


### PR DESCRIPTION
## 📝작업 내용

라이프스타일 입력 후 다음 화면으로 이동하는 버튼이 안보이는 문제 해결