### PR TITLE
Cozy 644 qa수정 4트

### DIFF
--- a/app/src/main/java/umc/cozymate/data/api/MemberStatService.kt
+++ b/app/src/main/java/umc/cozymate/data/api/MemberStatService.kt
@@ -33,7 +33,8 @@ interface MemberStatService {
     suspend fun getRoommateListByEquality(
         @Header("Authorization") accessToken: String,
         @Query("page") page: Int,
-        @Query("filterList") filterList: List<String>
+        @Query("filterList") filterList: List<String>,
+        @Query("hasRoom") hasRoom : Boolean
     ) : Response<GetRoommateListByEqualityResponse>
 
     // 필터링 사용자 목록 받아 오기 (상세 정보가 있을 때)

--- a/app/src/main/java/umc/cozymate/data/model/response/chat/ChatContentsResponse.kt
+++ b/app/src/main/java/umc/cozymate/data/model/response/chat/ChatContentsResponse.kt
@@ -22,7 +22,7 @@ data class ChatContentsResponse(
     @Serializable
     data class ChatRoomInfo(
         @SerializedName("memberId")
-        val memberId : Int,
+        val memberId : Int?,
         @SerializedName("content")
         var content : List<ChatContentData>
     )

--- a/app/src/main/java/umc/cozymate/data/repository/repository/MemberStatRepository.kt
+++ b/app/src/main/java/umc/cozymate/data/repository/repository/MemberStatRepository.kt
@@ -12,7 +12,7 @@ interface MemberStatRepository {
 
     suspend fun getRecommendedRoommateList(accessToken: String): Response<GetRecommendedRoommateResponse>
 
-    suspend fun getRoommateListByEquality(accessToken: String, page: Int, filterList: List<String>): Response<GetRoommateListByEqualityResponse>
+    suspend fun getRoommateListByEquality(accessToken: String, page: Int, filterList: List<String>, hasRoom : Boolean): Response<GetRoommateListByEqualityResponse>
 
     suspend fun getMemberDetailInfo(accessToken: String, memberId: Int): Response<GetMemberDetailInfoResponse>
 }

--- a/app/src/main/java/umc/cozymate/data/repository/repositoryImpl/MemberStatRepositoryImpl.kt
+++ b/app/src/main/java/umc/cozymate/data/repository/repositoryImpl/MemberStatRepositoryImpl.kt
@@ -29,9 +29,10 @@ class MemberStatRepositoryImpl @Inject constructor(
     override suspend fun getRoommateListByEquality(
         accessToken: String,
         page: Int,
-        filterList: List<String>
+        filterList: List<String>,
+        hasRoom : Boolean
     ): Response<GetRoommateListByEqualityResponse> {
-        return api.getRoommateListByEquality(accessToken, page, filterList)
+        return api.getRoommateListByEquality(accessToken, page, filterList, hasRoom)
     }
 
     override suspend fun getMemberDetailInfo(

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/roommate/roommate_detail/RoommateDetailActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/roommate/roommate_detail/RoommateDetailActivity.kt
@@ -131,6 +131,11 @@ class RoommateDetailActivity : AppCompatActivity() {
             binding.progressBar.visibility = if (isLoading) View.VISIBLE else View.GONE
         }
 
+        reportViewModel.isSuccess.observe(this){ isSuccess ->
+            if (isSuccess == null) return@observe
+            if(isSuccess) Toast.makeText(this, "신고가 정상적으로 접수되었습니다", Toast.LENGTH_SHORT).show()
+        }
+
 
     }
 
@@ -1542,7 +1547,7 @@ class RoommateDetailActivity : AppCompatActivity() {
                 reportViewModel.postReport(memberId, 0, reason, content)
             }
         })
-        dialog.show(this.supportFragmentManager!!, "reportPopup")
+        dialog.show(this.supportFragmentManager, "reportPopup")
     }
 
     private fun createFallbackUserDetail(): GetMemberDetailInfoResponse.Result {

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/roommate/roommate_detail/RoommateDetailHeaderViewHolder.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/roommate/roommate_detail/RoommateDetailHeaderViewHolder.kt
@@ -3,6 +3,7 @@ package umc.cozymate.ui.cozy_home.roommate.roommate_detail
 import android.content.Intent
 import android.util.Log
 import android.view.Gravity
+import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
 import android.widget.LinearLayout
@@ -20,10 +21,12 @@ import umc.cozymate.util.fromDpToPx
 class RoommateDetailHeaderViewHolder(
     private val binding: RvItemRoomateDetailHeaderBinding,
     private val itemClick: RoommateRecommendRVAdapter.clickListener,
+    private val isLifestyleExist: Boolean
 ) : RecyclerView.ViewHolder(binding.root) {
     private val  selectedChips = mutableListOf<String>()
     private var chips  = mutableListOf<CheckBox>()
     private var isClear : Boolean = false
+
     fun bind(){
         // 검색창 이동
         binding.lyRoomMateSearch.setOnClickListener {
@@ -41,6 +44,11 @@ class RoommateDetailHeaderViewHolder(
             context.startActivity(intent)
         }
         initChip()
+        binding.layoutCheckbox.visibility = if(isLifestyleExist) View.VISIBLE else View.GONE
+        binding.cbCheck.setOnCheckedChangeListener { _, isChecked ->
+            // false 가 방이 없는것으로 추정?
+            itemClick.clickCheckBox(isChecked)
+        }
     }
 
     private fun initChip(){
@@ -94,6 +102,10 @@ class RoommateDetailHeaderViewHolder(
          for (c in chips) c.isChecked = false
         selectedChips.clear()
         isClear = false
+    }
+
+    fun setCheckbox(hasRoom: Boolean){
+        binding.cbCheck.isChecked = hasRoom
     }
 
 }

--- a/app/src/main/java/umc/cozymate/ui/cozy_home/roommate/roommate_detail/RoommateRecommendRVAdapter.kt
+++ b/app/src/main/java/umc/cozymate/ui/cozy_home/roommate/roommate_detail/RoommateRecommendRVAdapter.kt
@@ -19,7 +19,7 @@ import umc.cozymate.util.fromDpToPx
 class RoommateRecommendRVAdapter(
     private val isLifestyleExist: Boolean,
     private val isEmpty: Boolean,
-    private val itemClick : clickListener
+    private val itemClick : clickListener,
 ) : ListAdapter<RoommateRecommendRVAdapter.RecyclerItem, RecyclerView.ViewHolder>(RoommateRecommendRVAdapterDiffCallback) {
 
     companion object {
@@ -52,7 +52,7 @@ class RoommateRecommendRVAdapter(
             VIEW_TYPE_FIRST -> {
                 val binding = RvItemRoomateDetailHeaderBinding.inflate(inflater, parent, false)
                 binding.root.layoutParams =layoutParams
-                return RoommateDetailHeaderViewHolder(binding, itemClick)
+                return RoommateDetailHeaderViewHolder(binding, itemClick,  isLifestyleExist)
             }
             VIEW_TYPE_SECOND -> {
                 val binding = VpItemRoommateRecommendBinding.inflate(inflater, parent, false)
@@ -117,5 +117,6 @@ object RoommateRecommendRVAdapterDiffCallback : DiffUtil.ItemCallback<RoommateRe
     interface clickListener{
         fun clickFilter(list: List<String>)
         fun moveDetailView(memberId : Int)
+        fun clickCheckBox(isChecked: Boolean)
     }
 }

--- a/app/src/main/java/umc/cozymate/ui/message/MessageDetailActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/message/MessageDetailActivity.kt
@@ -170,7 +170,7 @@ class MessageDetailActivity : AppCompatActivity() {
     private fun reportPopup(){
         val dialog = ReportPopup(object : PopupClick {
             override fun reportFunction(reason: Int, content : String) {
-                reportViewModel.postReport(memberId!!, 1, reason, content)
+                reportViewModel.postReport(memberId, 1, reason, content)
             }
         })
         dialog.show(this.supportFragmentManager, "reportPopup")

--- a/app/src/main/java/umc/cozymate/ui/message/MessageDetailActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/message/MessageDetailActivity.kt
@@ -33,7 +33,7 @@ class MessageDetailActivity : AppCompatActivity() {
     private val viewModel : MessageViewModel by viewModels()
     private val reportViewModel : ReportViewModel by viewModels()
     private var chatRoomId : Int = 0
-    private var memberId : Int = 0
+    private var memberId : Int = -1
     private var nickname :String = ""
     private var page : Int = 0
     private var isLastPage: Boolean  = false
@@ -48,7 +48,6 @@ class MessageDetailActivity : AppCompatActivity() {
         binding = ActivityMessageDetailBinding.inflate(layoutInflater)
         StatusBarUtil.updateStatusBarColor(this, Color.WHITE)
         setContentView(binding.root)
-        memberId = intent.getIntExtra("userId",0)
         nickname = intent.getStringExtra("nickname").toString()
         chatRoomId = intent.getIntExtra("chatRoomId",0)
         setupObservers()
@@ -75,9 +74,9 @@ class MessageDetailActivity : AppCompatActivity() {
     }
 
     private fun setupObservers() {
-        viewModel.chatContents.observe(this, Observer{
-            if (it == null) return@Observer
-            if(it.isEmpty() && page <=1 ){
+        viewModel.chatContents.observe(this, Observer{ data ->
+            if (data == null) return@Observer
+            if(data.isEmpty() && page <=1 ){
                 val text = "[$nickname]님과\n아직 주고 받은 쪽지가 없어요!"
                 binding.tvEmpty.text = text
                 binding.rvMessageDetail.visibility = View.GONE
@@ -85,13 +84,20 @@ class MessageDetailActivity : AppCompatActivity() {
             }
             else{
                 Log.d(TAG,"page $page")
-                if (it.size < ITEM_SIZE ) isLastPage = true
-                messageDetailAdapter.addData(it,isLastPage)
+                if (data.size < ITEM_SIZE ) isLastPage = true
+                messageDetailAdapter.addData(data,isLastPage)
                 binding.rvMessageDetail.visibility = View.VISIBLE
                 binding.tvEmpty.visibility = View.GONE
 
             }
         })
+        viewModel.memberId.observe(this){id->
+            Log.d(TAG,"memberID : ${id}")
+            if(id == null){
+                binding.btnWriteMessage.visibility = View.GONE
+            }
+            else memberId = id
+        }
         viewModel.isLoading.observe(this) { isLoading ->
             if(!binding.refreshLayout.isRefreshing)
                 binding.progressBar.visibility = if (isLoading) View.VISIBLE else View.GONE
@@ -142,7 +148,8 @@ class MessageDetailActivity : AppCompatActivity() {
         }
 
         binding.ivMore.setOnClickListener {
-            this.showEnumBottomSheet( "", listOf(DELETE,REPORT)) { action->
+            val buttons = if (memberId <0) listOf(DELETE)else listOf(DELETE,REPORT)
+            this.showEnumBottomSheet( "", buttons) { action->
                 when (action) {
                     DELETE  -> deletePopup()
                     REPORT ->  reportPopup()
@@ -163,7 +170,7 @@ class MessageDetailActivity : AppCompatActivity() {
     private fun reportPopup(){
         val dialog = ReportPopup(object : PopupClick {
             override fun reportFunction(reason: Int, content : String) {
-                reportViewModel.postReport(memberId, 1, reason, content)
+                reportViewModel.postReport(memberId!!, 1, reason, content)
             }
         })
         dialog.show(this.supportFragmentManager, "reportPopup")

--- a/app/src/main/java/umc/cozymate/ui/message/MessageDetailActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/message/MessageDetailActivity.kt
@@ -85,8 +85,8 @@ class MessageDetailActivity : AppCompatActivity() {
             }
             else{
                 Log.d(TAG,"page $page")
-                messageDetailAdapter.addData(it)
                 if (it.size < ITEM_SIZE ) isLastPage = true
+                messageDetailAdapter.addData(it,isLastPage)
                 binding.rvMessageDetail.visibility = View.VISIBLE
                 binding.tvEmpty.visibility = View.GONE
 

--- a/app/src/main/java/umc/cozymate/ui/message/MessageDetailAdapter.kt
+++ b/app/src/main/java/umc/cozymate/ui/message/MessageDetailAdapter.kt
@@ -10,9 +10,9 @@ import umc.cozymate.data.model.entity.ChatContentData
 import umc.cozymate.databinding.RvItemMessageBinding
 
 class MessageDetailAdapter(
-
 ) : RecyclerView.Adapter<MessageDetailAdapter.MessageDetailViewHolder>() {
     private var messageList = mutableListOf<ChatContentData>()
+    private var pageFlag : Boolean = false
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MessageDetailViewHolder {
         val binding = RvItemMessageBinding.inflate(
@@ -21,19 +21,25 @@ class MessageDetailAdapter(
     }
 
     override fun onBindViewHolder(holder: MessageDetailViewHolder, position: Int) {
-        holder.bind(position)
+        if(pageFlag && position == messageList.size ) holder.emptyBind()
+        else holder.bind(position)
     }
 
     override fun getItemCount(): Int =  messageList.size
 
-    fun addData(newData: List<ChatContentData>) {
+    fun addData(newData: List<ChatContentData>, isLast : Boolean) {
         val startPosition = messageList.size
         messageList.addAll(newData)
+        if (isLast) {
+            pageFlag = isLast
+            messageList.add(ChatContentData())
+        }
         notifyItemRangeInserted(startPosition, newData.size)
     }
 
     fun deleteList(){
         messageList.clear()
+        pageFlag = false
         notifyDataSetChanged()
     }
 
@@ -43,8 +49,7 @@ class MessageDetailAdapter(
     ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(pos : Int) {
-            Log.d("test", "pos : $pos / size ${messageList.size}")
-            val item =  messageList[pos]
+            val  item= messageList[pos]
             val nickname = item.nickname
             binding.tvMessageName.text = nickname
             binding.tvMessageText.text = item.content
@@ -57,6 +62,12 @@ class MessageDetailAdapter(
             }
             binding.ivLine.visibility =  if(pos ==  messageList.size-1 && (pos+1)%10 != 0)  View.GONE else View.VISIBLE
 
+        }
+        fun emptyBind(){
+            binding.tvMessageName.visibility = View.GONE
+            binding.tvMessageText.visibility = View.GONE
+            binding.tvMessageTime.visibility = View.GONE
+            binding.ivLine.visibility = View.GONE
         }
 
     }

--- a/app/src/main/java/umc/cozymate/ui/message/MessageMemberActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/message/MessageMemberActivity.kt
@@ -51,6 +51,7 @@ class MessageMemberActivity : AppCompatActivity() {
     }
     override fun onResume() {
         super.onResume()
+        clearPage()
         viewModel.getChatRooms( page++, ITEM_SIZE)
     }
 

--- a/app/src/main/java/umc/cozymate/ui/message/WriteMessageActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/message/WriteMessageActivity.kt
@@ -77,30 +77,31 @@ class WriteMessageActivity : AppCompatActivity() {
 
     // 밖 터치시 키보드 숨기기
     override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
-        if(ev!!.action ==  MotionEvent.ACTION_UP)
+        if(ev?.action == MotionEvent.ACTION_UP)
             prev = currentFocus
         val result = super.dispatchTouchEvent(ev)
-        mDetector.onTouchEvent(ev)
+        ev?.let { mDetector.onTouchEvent(it) }
         return result
     }
 
     private inner class SingleTapListener : GestureDetector.SimpleOnGestureListener() {
         override fun onSingleTapUp(e: MotionEvent): Boolean {
-            // ACTION_UP 이벤트에서 포커스를 가진 뷰가 EditText일 때 터치 영역을 확인하여 키보드를 토글
-            if (e.action == MotionEvent.ACTION_UP && prev is EditText) {
+            if (prev is EditText) {
                 val prevFocus = prev ?: return false
-                // 포커를 가진 EditText의 터치 영역 계산
-                val hitRect = Rect()
-                prevFocus.getGlobalVisibleRect(hitRect)
+                val location = IntArray(2)
+                prevFocus.getLocationOnScreen(location)
+                val hitRect = Rect(
+                    location[0],
+                    location[1],
+                    location[0] + prevFocus.width,
+                    location[1] + prevFocus.height
+                )
 
-                // 터치 이벤트가 EditText의 터치 영역에 속하지 않을 때 키보드를 숨길지 결정
-                if (!hitRect.contains(e.x.toInt(), e.y.toInt())) {
+                if (!hitRect.contains(e.rawX.toInt(), e.rawY.toInt())) {
                     if (currentFocus is EditText && currentFocus != prevFocus) {
-                        // 터치한 영역의 뷰가 다른 EditText일 때는 키보드를 가리지 않는다.
                         return false
                     } else {
                         val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-                        // 터치한 영역이 EditText의 터치 영역 밖이면서 다른 EditText가 아닐 때 키보드 hide
                         imm.hideSoftInputFromWindow(prevFocus.windowToken, 0)
                         prevFocus.clearFocus()
                     }
@@ -109,6 +110,7 @@ class WriteMessageActivity : AppCompatActivity() {
             return super.onSingleTapUp(e)
         }
     }
+
     private fun checkInput(overflow: Boolean = false) {
         binding.btnInputButton.isEnabled = !(binding.etInputMessage.text.isNullOrEmpty() || overflow)
     }

--- a/app/src/main/java/umc/cozymate/ui/my_page/withdraw/WithDrawActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/withdraw/WithDrawActivity.kt
@@ -5,11 +5,17 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.res.ColorStateList
 import android.graphics.Color
+import android.graphics.Rect
 import android.os.Bundle
 import android.util.Log
+import android.view.GestureDetector
+import android.view.MotionEvent
 import android.view.View
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.GestureDetectorCompat
 import androidx.core.widget.CompoundButtonCompat
 import androidx.lifecycle.Observer
 import dagger.hilt.android.AndroidEntryPoint
@@ -24,14 +30,19 @@ class WithDrawActivity : AppCompatActivity() {
     private val TAG = this.javaClass.simpleName
     private lateinit var binding: ActivityWithdrawBinding
     private lateinit var spf : SharedPreferences
+    private lateinit var mDetector: GestureDetectorCompat
     private var reason : String = ""
     private var memberId : Int = 0
     private var nickname: String = ""
     private val viewModel : SplashViewModel by viewModels()
+    private var prev : View? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityWithdrawBinding.inflate(layoutInflater)
         spf = getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
+        mDetector = GestureDetectorCompat(this, SingleTapListener())
+
         setContentView(binding.root)
         StatusBarUtil.updateStatusBarColor(this, Color.WHITE) // 상단바 색상 수정
         setTextContent()
@@ -101,5 +112,40 @@ class WithDrawActivity : AppCompatActivity() {
 
         // 화면 크기와 텍스트 길이를 비교하여 텍스트 설정
         binding.tvSplitText.text = if (textWidth+padding > screenWidth) splitText else originalText
+    }
+
+    // 밖 터치시 키보드 숨기기
+    override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
+        if(ev!!.action ==  MotionEvent.ACTION_UP)
+            prev = currentFocus
+        val result = super.dispatchTouchEvent(ev)
+        mDetector.onTouchEvent(ev)
+        return result
+    }
+
+    private inner class SingleTapListener : GestureDetector.SimpleOnGestureListener() {
+        override fun onSingleTapUp(e: MotionEvent): Boolean {
+            // ACTION_UP 이벤트에서 포커스를 가진 뷰가 EditText일 때 터치 영역을 확인하여 키보드를 토글
+            if (e.action == MotionEvent.ACTION_UP && prev is EditText) {
+                val prevFocus = prev ?: return false
+                // 포커를 가진 EditText의 터치 영역 계산
+                val hitRect = Rect()
+                prevFocus.getGlobalVisibleRect(hitRect)
+
+                // 터치 이벤트가 EditText의 터치 영역에 속하지 않을 때 키보드를 숨길지 결정
+                if (!hitRect.contains(e.x.toInt(), e.y.toInt())) {
+                    if (currentFocus is EditText && currentFocus != prevFocus) {
+                        // 터치한 영역의 뷰가 다른 EditText일 때는 키보드를 가리지 않는다.
+                        return false
+                    } else {
+                        val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                        // 터치한 영역이 EditText의 터치 영역 밖이면서 다른 EditText가 아닐 때 키보드 hide
+                        imm.hideSoftInputFromWindow(prevFocus.windowToken, 0)
+                        prevFocus.clearFocus()
+                    }
+                }
+            }
+            return super.onSingleTapUp(e)
+        }
     }
 }

--- a/app/src/main/java/umc/cozymate/ui/my_page/withdraw/WithDrawActivity.kt
+++ b/app/src/main/java/umc/cozymate/ui/my_page/withdraw/WithDrawActivity.kt
@@ -116,36 +116,38 @@ class WithDrawActivity : AppCompatActivity() {
 
     // 밖 터치시 키보드 숨기기
     override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
-        if(ev!!.action ==  MotionEvent.ACTION_UP)
+        if(ev?.action == MotionEvent.ACTION_UP)
             prev = currentFocus
         val result = super.dispatchTouchEvent(ev)
-        mDetector.onTouchEvent(ev)
+        ev?.let { mDetector.onTouchEvent(it) }
         return result
     }
 
+
     private inner class SingleTapListener : GestureDetector.SimpleOnGestureListener() {
         override fun onSingleTapUp(e: MotionEvent): Boolean {
-            // ACTION_UP 이벤트에서 포커스를 가진 뷰가 EditText일 때 터치 영역을 확인하여 키보드를 토글
-            if (e.action == MotionEvent.ACTION_UP && prev is EditText) {
-                val prevFocus = prev ?: return false
-                // 포커를 가진 EditText의 터치 영역 계산
-                val hitRect = Rect()
-                prevFocus.getGlobalVisibleRect(hitRect)
+                if (prev is EditText) {
+                    val prevFocus = prev ?: return false
+                    val location = IntArray(2)
+                    prevFocus.getLocationOnScreen(location)
+                    val hitRect = Rect(
+                        location[0],
+                        location[1],
+                        location[0] + prevFocus.width,
+                        location[1] + prevFocus.height
+                    )
 
-                // 터치 이벤트가 EditText의 터치 영역에 속하지 않을 때 키보드를 숨길지 결정
-                if (!hitRect.contains(e.x.toInt(), e.y.toInt())) {
-                    if (currentFocus is EditText && currentFocus != prevFocus) {
-                        // 터치한 영역의 뷰가 다른 EditText일 때는 키보드를 가리지 않는다.
-                        return false
-                    } else {
-                        val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-                        // 터치한 영역이 EditText의 터치 영역 밖이면서 다른 EditText가 아닐 때 키보드 hide
-                        imm.hideSoftInputFromWindow(prevFocus.windowToken, 0)
-                        prevFocus.clearFocus()
+                    if (!hitRect.contains(e.rawX.toInt(), e.rawY.toInt())) {
+                        if (currentFocus is EditText && currentFocus != prevFocus) {
+                            return false
+                        } else {
+                            val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                            imm.hideSoftInputFromWindow(prevFocus.windowToken, 0)
+                            prevFocus.clearFocus()
+                        }
+                        }
                     }
-                }
-            }
-            return super.onSingleTapUp(e)
+                    return super.onSingleTapUp(e)
         }
     }
 }

--- a/app/src/main/java/umc/cozymate/ui/viewmodel/CozyHomeViewModel.kt
+++ b/app/src/main/java/umc/cozymate/ui/viewmodel/CozyHomeViewModel.kt
@@ -115,7 +115,8 @@ class CozyHomeViewModel @Inject constructor(
                     val response = memberStatRepository.getRoommateListByEquality(
                         accessToken = token,
                         page = page,
-                        filter
+                        filter,
+                        hasRoom = false
                     )
                     if (response.isSuccessful) {
                         if (response.body()?.isSuccess == true) {

--- a/app/src/main/java/umc/cozymate/ui/viewmodel/MessageViewModel.kt
+++ b/app/src/main/java/umc/cozymate/ui/viewmodel/MessageViewModel.kt
@@ -31,8 +31,8 @@ class MessageViewModel @Inject constructor(
     private val _chatContents = MutableLiveData<List<ChatContentData>>()
     val chatContents : LiveData<List<ChatContentData>> get() = _chatContents
 
-    private val _memberId = MutableLiveData<Int>()
-    val memberId : LiveData<Int> get() = _memberId
+    private val _memberId = MutableLiveData<Int?>()
+    val memberId : LiveData<Int?> get() = _memberId
 
     private val _chatRooms = MutableLiveData<List<ChatRoomData>>()
     val chatRooms : LiveData<List<ChatRoomData>> get() = _chatRooms
@@ -52,9 +52,10 @@ class MessageViewModel @Inject constructor(
                 _isLoading.value = true
                 val response = repository.getChatContents(token!!, chatRoomId, page, size)
                 if(response.isSuccessful){
-                    val chatRoomInfo = response.body()!!.result.result
-                    _chatContents.postValue(chatRoomInfo.content)
-                    _memberId.postValue(chatRoomInfo.memberId)
+                    response.body()?.result?.result?.let { chatRoomInfo ->
+                        _chatContents.postValue(chatRoomInfo.content)
+                        _memberId.postValue(chatRoomInfo.memberId)
+                        }
                     Log.d(TAG, "getChatContents api 응답 성공: ${response.body()!!.result.result}")
                 }
                 else Log.d(TAG, "getChatContents api 응답 실패: ${response.body()!!.result}")

--- a/app/src/main/java/umc/cozymate/ui/viewmodel/MessageViewModel.kt
+++ b/app/src/main/java/umc/cozymate/ui/viewmodel/MessageViewModel.kt
@@ -10,12 +10,9 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
 import retrofit2.Response
-import umc.cozymate.data.DefaultResponse
 import umc.cozymate.data.model.entity.ChatContentData
 import umc.cozymate.data.model.entity.ChatRoomData
 import umc.cozymate.data.model.request.ChatRequest
-import umc.cozymate.data.model.response.chat.ChatContentsResponse
-import umc.cozymate.data.model.response.chat.ChatRoomResponse
 import umc.cozymate.data.model.response.chat.WriteChatResponse
 import umc.cozymate.data.repository.repository.ChatRepository
 import javax.inject.Inject
@@ -33,6 +30,9 @@ class MessageViewModel @Inject constructor(
 
     private val _chatContents = MutableLiveData<List<ChatContentData>>()
     val chatContents : LiveData<List<ChatContentData>> get() = _chatContents
+
+    private val _memberId = MutableLiveData<Int>()
+    val memberId : LiveData<Int> get() = _memberId
 
     private val _chatRooms = MutableLiveData<List<ChatRoomData>>()
     val chatRooms : LiveData<List<ChatRoomData>> get() = _chatRooms
@@ -52,8 +52,9 @@ class MessageViewModel @Inject constructor(
                 _isLoading.value = true
                 val response = repository.getChatContents(token!!, chatRoomId, page, size)
                 if(response.isSuccessful){
-                    val content = response.body()!!.result.result.content
-                    _chatContents.postValue(content)
+                    val chatRoomInfo = response.body()!!.result.result
+                    _chatContents.postValue(chatRoomInfo.content)
+                    _memberId.postValue(chatRoomInfo.memberId)
                     Log.d(TAG, "getChatContents api 응답 성공: ${response.body()!!.result.result}")
                 }
                 else Log.d(TAG, "getChatContents api 응답 실패: ${response.body()!!.result}")
@@ -107,7 +108,7 @@ class MessageViewModel @Inject constructor(
                 val response = repository.getChatRooms(token!!, page, size)
                 if(response.isSuccessful){
                     val content = response.body()!!.result.result
-                    _chatRooms.postValue( content)
+                    _chatRooms.postValue(content)
                     Log.d(TAG, "getChatRooms api 응답 성공: ${response.body()!!.result.result}")
                 }
                 else Log.d(TAG, "getChatRooms api 응답 실패: ${response.body()!!.result}")

--- a/app/src/main/java/umc/cozymate/ui/viewmodel/RoommateRecommendViewModel.kt
+++ b/app/src/main/java/umc/cozymate/ui/viewmodel/RoommateRecommendViewModel.kt
@@ -55,14 +55,14 @@ class RoommateRecommendViewModel @Inject constructor(
             }
         }
     }
-    fun fetchRoommateListByEquality(filter : List<String> = emptyList(), page : Int = 0) { // 라이프스타일 있을 때
+    fun fetchRoommateListByEquality(filter : List<String> = emptyList(), page : Int = 0, hasRoom : Boolean) { // 라이프스타일 있을 때
         val token = getToken()
         // 마지막 페이지 일 경우 요정 x
         if (!hasNext && page != 0) return
         viewModelScope.launch {
             _isLoading.value = true
             try {
-                val response = repository.getRoommateListByEquality(accessToken = token!!, page=page, filter)
+                val response = repository.getRoommateListByEquality(accessToken = token!!, page=page, filter, hasRoom)
                 if (response.isSuccessful) {
                     if (response.body()?.isSuccess == true) {
                         Log.d(TAG, "추천 룸메이트 리스트 조회 성공: ${response.body()!!.result}")

--- a/app/src/main/java/umc/cozymate/util/BottomSheetUtil.kt
+++ b/app/src/main/java/umc/cozymate/util/BottomSheetUtil.kt
@@ -41,6 +41,9 @@ fun Context.showEnumBottomSheet(
             onAction(actions[1])
             dialog.dismiss()
         }
+    }else{
+        binding.tvBottom.visibility = View.GONE
+        binding.line.visibility = View.GONE
     }
 
     dialog.setContentView(binding.root)

--- a/app/src/main/res/layout/rv_item_roomate_detail_header.xml
+++ b/app/src/main/res/layout/rv_item_roomate_detail_header.xml
@@ -66,6 +66,31 @@
         android:layout_marginBottom="22dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/ly_room_mate_search" />
+    <LinearLayout
+        android:id="@+id/layout_checkbox"
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        android:orientation="horizontal"
+        android:gravity="end|center_vertical"
+        android:layout_marginTop="10dp"
+        android:layout_marginHorizontal="20dp"
+        app:layout_constraintTop_toBottomOf="@id/chips">
+        <CheckBox
+            android:id="@+id/cb_check"
+            android:layout_width="22dp"
+            android:layout_height="22dp"
+            android:button="@null"
+            android:layout_margin="9dp"
+            android:background="@drawable/ic_checkbox" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="40dp"
+            android:text="방이 없는 사용자만 보기"
+            android:gravity="end|center_vertical"
+            android:textColor="@color/basic_font"
+            android:textAppearance="@style/TextAppearance.App.14sp.Medium"/>
+
+    </LinearLayout>
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 📝작업 내용
- 쪽지 방 조회시 바로 적용이 안되었던 문제 해결
- 쪽지 내용 조회시 아래 여백 추가
- 룸메 상세페이지 신고하기 토스트 메시지 추가
- 룸메 추천 룸메없는 사용자 보기 기능 추가
- 탈퇴하기 외부클릭시 키보드 내려가도록 설정
- 쪽지 내용 조회시 탈퇴한 사용자 쪽지쓰기, 신고하기 버튼 제거 

### 스크린샷 (선택)
![KakaoTalk_20250706_234026599](https://github.com/user-attachments/assets/da427489-886f-4e7d-8dcd-e05793b97ce8)
![KakaoTalk_20250706_234026599_02](https://github.com/user-attachments/assets/04d67c29-9763-4a0c-8d95-55026337f2fc)
![KakaoTalk_20250706_234026599_01](https://github.com/user-attachments/assets/e19f9f91-1857-49c2-86e2-dad6c0c56aa0)


## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 룸메이트 상세 화면에 "방이 없는 사용자만 보기" 체크박스가 추가되어, 체크 시 해당 조건에 맞는 사용자만 목록에 표시됩니다.
  * 채팅 목록에서 마지막 페이지일 때 빈 항목이 표시되어 데이터의 끝을 명확히 확인할 수 있습니다.

* **개선 및 변경**
  * 채팅 상세 화면에서 사용자 ID가 없을 경우 메시지 작성 버튼이 숨겨집니다.
  * 채팅방 목록이 새로고침될 때 항상 첫 페이지부터 데이터를 불러옵니다.
  * 채팅 상세, 메시지 작성, 회원 탈퇴 화면에서 EditText 외부 터치 시 키보드가 자동으로 숨겨집니다.
  * 신고 성공 시 토스트 메시지가 표시되고, 특정 오류 코드도 성공으로 처리됩니다.
  * 하단 시트 메뉴에서 선택지가 한 개일 때 불필요한 구분선과 텍스트가 숨겨집니다.

* **버그 수정**
  * 다이얼로그 표시 시 불필요한 널 체크가 제거되어 안정성이 향상되었습니다.

* **UI/UX 개선**
  * 룸메이트 추천 목록, 헤더, 어댑터 등에서 체크박스 상태 및 필터 연동이 개선되어 사용성이 향상되었습니다.
  * 체크박스, 필터, 페이지 이동 등 다양한 상호작용에서 UI 상태가 일관되게 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->